### PR TITLE
ユニットテスト用の関数を切り出した。

### DIFF
--- a/parse.c
+++ b/parse.c
@@ -1,3 +1,4 @@
+#include <stdio.h>
 #include <unistd.h>
 
 #include "parse.h"

--- a/parse2.c
+++ b/parse2.c
@@ -1,3 +1,4 @@
+#include <stdio.h>
 #include "parse.h"
 
 int	parse_is_special_char(char ch)

--- a/test/Makefile
+++ b/test/Makefile
@@ -1,7 +1,5 @@
 run: parse_test
 	./parse_test
 
-parse_test: parse_test.c Makefile ../parse.c ../parse2.c ../parse.h
-	gcc -g -o $@ parse_test.c
-	gcc -Wall -Wextra -g -o $@ parse_test.c
-
+parse_test: Makefile parse_test.c test.c test.h ../parse.c ../parse2.c ../parse.h
+	gcc -Wall -Wextra -g -o $@ parse_test.c test.c ../parse.c ../parse2.c

--- a/test/parse_test.c
+++ b/test/parse_test.c
@@ -1,34 +1,5 @@
-#include <stdio.h>
-#include <string.h>
-#include <stdint.h>
-#include "../parse.c"
-#include "../parse2.c"
-
-int		success_count = 0;
-int		fail_count = 0;
-
-void	check(int64_t val, const char *msg)
-{
-	if (val)
-	{
-		success_count++;
-		printf("  ✔ %s\n", msg);
-	}
-	else
-	{
-		fail_count++;
-		printf("  ✖ %s\n", msg);
-	}
-}
-
-void	print_result()
-{
-	printf("✔: %d ✖: %d\n", success_count, fail_count);
-}
-
-#define CHECK(val) check((int64_t)val, #val)
-#define CHECK_EQ(actual, expected) check(actual == expected, #actual " == " #expected)
-#define TEST_SECTION(message) printf("- " message "\n")
+#include "test.h"
+#include "../parse.h"
 
 void	init_buf_with_string(t_parse_buffer *buf, const char* str)
 {
@@ -157,6 +128,6 @@ int main()
         CHECK_EQ(tok.type, TOKTYPE_SEMICOLON);
     }
 
-	print_result();
+	int fail_count = print_result();
 	return (fail_count);
 }

--- a/test/test.c
+++ b/test/test.c
@@ -1,0 +1,25 @@
+#include <stdint.h>
+#include <stdio.h>
+
+int	g_success_count = 0;
+int	g_fail_count = 0;
+
+void	test_check(int64_t val, const char *msg)
+{
+	if (val)
+	{
+		g_success_count++;
+		printf("  ✔ %s\n", msg);
+	}
+	else
+	{
+		g_fail_count++;
+		printf("  ✖ %s\n", msg);
+	}
+}
+
+int	print_result()
+{
+	printf("✔: %d ✖: %d\n", g_success_count, g_fail_count);
+	return (g_fail_count);
+}

--- a/test/test.h
+++ b/test/test.h
@@ -8,3 +8,6 @@
 
 void	test_check(int64_t val, const char *msg);
 int	print_result();
+
+extern int	g_success_count;
+extern int	g_fail_count;

--- a/test/test.h
+++ b/test/test.h
@@ -1,0 +1,10 @@
+#include <stdio.h>
+#include <string.h>
+#include <stdint.h>
+
+#define CHECK(val) test_check((int64_t)val, #val)
+#define CHECK_EQ(actual, expected) test_check(actual == expected, #actual " == " #expected)
+#define TEST_SECTION(message) printf("- " message "\n")
+
+void	test_check(int64_t val, const char *msg);
+int	print_result();


### PR DESCRIPTION
ユニットテストで使っている関数を test.c に切り出しました。
`print_result()` で失敗したテストの数を返すようにしましhた。

既存のテストコードもこれに合わせてあとで書き直します。