### PR TITLE
Norminette をローカルで動かすための Docker の設定と make ルールを追加。

### DIFF
--- a/test/Dockerfile
+++ b/test/Dockerfile
@@ -1,0 +1,2 @@
+FROM python:buster
+RUN python3 -m pip install norminette

--- a/test/Makefile
+++ b/test/Makefile
@@ -3,3 +3,6 @@ run: parse_test
 
 parse_test: Makefile parse_test.c test.c test.h ../parse.c ../parse2.c ../parse.h
 	gcc -Wall -Wextra -g -o $@ parse_test.c test.c ../parse.c ../parse2.c
+
+norm:
+	sudo docker-compose run norm norminette ../*.[ch]

--- a/test/Makefile
+++ b/test/Makefile
@@ -5,4 +5,4 @@ parse_test: Makefile parse_test.c test.c test.h ../parse.c ../parse2.c ../parse.
 	gcc -Wall -Wextra -g -o $@ parse_test.c test.c ../parse.c ../parse2.c
 
 norm:
-	sudo docker-compose run norm norminette ../*.[ch]
+	docker-compose run --rm norm norminette ../*.[ch]

--- a/test/docker-compose.yml
+++ b/test/docker-compose.yml
@@ -1,0 +1,7 @@
+version: "3"
+services:
+  norm:
+    build: .
+    volumes:
+      - "..:/code"
+    working_dir: "/code/test"


### PR DESCRIPTION
test ディレクトリで `make norm` とすると Docker が起動して Norminette が動きます。

ディレクトリを再帰的に探索しないので Libft などの中身までは検証しませんが、開発中のテスト用途ならこのくらいでいいかなと思ってますがどうでしょう？