### PR TITLE
CHECK_TRUE() を削除. CWDでの実行可能ファイル検索関数を復元.

### DIFF
--- a/exec.c
+++ b/exec.c
@@ -58,6 +58,19 @@ char	*find_executable_file_from_path_env(char *filename)
 	return (executable_path);
 }
 
+char	*find_executable_file_in_cwd(char *filename)
+{
+	char	*cwdpath;
+	char	*executable_path;
+
+	cwdpath = getcwd(NULL, 0);
+	if (!cwdpath)
+		return (NULL);
+	executable_path = find_executable_file_in_dir(filename, cwdpath);
+	free(cwdpath);
+	return (executable_path);
+}
+
 /*
  * This function works just like execvp.
  *

--- a/test/command_exec_test.c
+++ b/test/command_exec_test.c
@@ -25,7 +25,7 @@ int main(){
 
 		command_execution(&command);
 		free_ptrarr((void**)command.exec_and_args);
-		CHECK_TRUE(system("diff /etc/passwd output.txt") == 0);
+		CHECK(system("diff /etc/passwd output.txt") == 0);
 		remove("output.txt");
     }
 
@@ -39,7 +39,7 @@ int main(){
 
 		command_execution(&command);
 		free_ptrarr((void**)command.exec_and_args);
-		CHECK_TRUE(system("diff /etc/passwd output.txt") == 0);
+		CHECK(system("diff /etc/passwd output.txt") == 0);
 		remove("output.txt");
     }
 
@@ -77,7 +77,7 @@ int main(){
 
 		command_execution(&command);
 		free_ptrarr((void**)command.exec_and_args);
-		CHECK_TRUE(system("diff test.h output.txt") == 0);
+		CHECK(system("diff test.h output.txt") == 0);
 		remove("output.txt");
     }
 
@@ -99,7 +99,7 @@ int main(){
 		command_execution(&cat_command);
 		free_ptrarr((void**)cat_command.exec_and_args);
 		free_ptrarr((void**)wc_command.exec_and_args);
-		CHECK_TRUE(system("diff <(cat /etc/passwd | wc) output.txt") == 0);
+		CHECK(system("diff <(cat /etc/passwd | wc) output.txt") == 0);
 		remove("output.txt");
     }
 	*/

--- a/test/test.h
+++ b/test/test.h
@@ -7,7 +7,6 @@
 #define CHECK(val) test_check((int64_t)val, #val)
 #define CHECK_EQ(actual, expected) test_check(actual == expected, #actual " == " #expected)
 #define CHECK_EQ_STR(actual, expected) test_check(strcmp(actual, expected) == 0, #actual " == " #expected)
-#define CHECK_TRUE(actual) test_check(actual, #actual " to be truthy")
 #define TEST_SECTION(message) printf("- " message "\n")
 
 void	test_check(int64_t val, const char *msg);


### PR DESCRIPTION
タイトル通りです.