### PR TITLE
AST データ構造とパーサ API の非互換な変更

### DIFF
--- a/minishell.c
+++ b/minishell.c
@@ -10,9 +10,9 @@ void	init_buffer(t_parse_buffer *buf)
 
 int	main(int argc, char **argv)
 {
-	t_parse_ast	*cmdline;
-	t_parse_buffer		buf;
-	t_token				tok;
+	t_parse_ast		*cmdline;
+	t_parse_buffer	buf;
+	t_token			tok;
 
 	init_buffer(&buf);
 	printf("Welcome Minishell\n");

--- a/minishell.c
+++ b/minishell.c
@@ -10,7 +10,7 @@ void	init_buffer(t_parse_buffer *buf)
 
 int	main(int argc, char **argv)
 {
-	t_parse_ast_node	*cmdline;
+	t_parse_ast	*cmdline;
 	t_parse_buffer		buf;
 	t_token				tok;
 

--- a/minishell.c
+++ b/minishell.c
@@ -20,9 +20,9 @@ int	main(int argc, char **argv)
 	{
 		printf("minish > ");
 		fflush(stdout);
-		cmdline = NULL;
 		lex_get_token(&buf, &tok);
-		if (parse_command_line(&buf, &cmdline, &tok) == PARSE_OK)
+		cmdline = parse_command_line(&buf, &tok);
+		if (cmdline)
 			printf("TODO: process the command line... %p\n", cmdline);
 		else
 			put_err_msg("Parse error.");

--- a/parse.h
+++ b/parse.h
@@ -32,38 +32,36 @@ typedef enum e_parse_ast_type
 	ASTNODE_INVALID,
 }	t_parse_ast_type;
 
-typedef struct s_parse_ast_node	t_parse_ast_node;
+typedef struct s_parse_ast	t_parse_ast;
 
 typedef struct s_parse_node_string
 {
 	const char				*text;
 	t_token_type			type;
-	t_parse_ast_node		*next;
+	t_parse_ast		*next;
 }	t_parse_node_string;
-
-typedef struct s_parse_ast_node	t_parse_ast_node;
 
 typedef struct s_parse_node_pipcmds
 {
-	t_parse_ast_node	*command_node;
-	t_parse_ast_node	*next;
+	t_parse_ast	*command_node;
+	t_parse_ast	*next;
 }	t_parse_node_pipcmds;
 
 typedef struct s_parse_node_command
 {
-	t_parse_ast_node	*arguments_node;
+	t_parse_ast	*arguments_node;
 }	t_parse_node_command;
 
 typedef struct s_parse_node_arguments
 {
-	t_parse_ast_node	*string_node;
-	t_parse_ast_node	*redirection_node;
-	t_parse_ast_node	*rest_node;
+	t_parse_ast	*string_node;
+	t_parse_ast	*redirection_node;
+	t_parse_ast	*rest_node;
 }	t_parse_node_arguments;
 
 typedef struct s_parse_node_redirection
 {
-	t_parse_ast_node	*string_node;
+	t_parse_ast	*string_node;
 	t_token_type		type;
 }	t_parse_node_redirection;
 
@@ -74,18 +72,18 @@ typedef struct s_parse_node_delimiter
 
 typedef struct s_parse_node_seqcmds
 {
-	t_parse_ast_node	*pipcmd_node;
-	t_parse_ast_node	*delimiter_node;
-	t_parse_ast_node	*rest_node;
+	t_parse_ast	*pipcmd_node;
+	t_parse_ast	*delimiter_node;
+	t_parse_ast	*rest_node;
 }	t_parse_node_seqcmds;
 
 typedef struct s_parse_node_cmdline
 {
-	t_parse_ast_node	*seqcmd_node;
-	t_parse_ast_node	*delimiter_node;
+	t_parse_ast	*seqcmd_node;
+	t_parse_ast	*delimiter_node;
 }	t_parse_node_cmdline;
 
-typedef struct s_parse_ast_node
+typedef struct s_parse_ast
 {
 	t_parse_ast_type	type;
 	union u_parse_ast_node_content
@@ -100,24 +98,24 @@ typedef struct s_parse_ast_node
 		t_parse_node_seqcmds		*sequential_commands;
 		t_parse_node_cmdline		*command_line;
 	}					content;
-}	t_parse_ast_node;
+}	t_parse_ast;
 
 t_parse_result	parse_redirection(
-					t_parse_buffer *buf, t_parse_ast_node **node, t_token *tok);
+					t_parse_buffer *buf, t_parse_ast **node, t_token *tok);
 t_parse_result	parse_string(
-					t_parse_buffer *buf, t_parse_ast_node **node, t_token *tok);
+					t_parse_buffer *buf, t_parse_ast **node, t_token *tok);
 t_parse_result	parse_arguments(
-					t_parse_buffer *buf, t_parse_ast_node **node, t_token *tok);
+					t_parse_buffer *buf, t_parse_ast **node, t_token *tok);
 t_parse_result	parse_command(
-					t_parse_buffer *buf, t_parse_ast_node **node, t_token *tok);
+					t_parse_buffer *buf, t_parse_ast **node, t_token *tok);
 t_parse_result	parse_piped_commands(
-					t_parse_buffer *buf, t_parse_ast_node **node, t_token *tok);
+					t_parse_buffer *buf, t_parse_ast **node, t_token *tok);
 t_parse_result	parse_delimiter(
-					t_parse_buffer *buf, t_parse_ast_node **node, t_token *tok);
+					t_parse_buffer *buf, t_parse_ast **node, t_token *tok);
 t_parse_result	parse_sequential_commands(
-					t_parse_buffer *buf, t_parse_ast_node **node, t_token *tok);
+					t_parse_buffer *buf, t_parse_ast **node, t_token *tok);
 t_parse_result	parse_command_line(
-					t_parse_buffer *buf, t_parse_ast_node **node, t_token *tok);
+					t_parse_buffer *buf, t_parse_ast **node, t_token *tok);
 
 void			parse_skip_spaces(t_parse_buffer *buf, t_token *tok);
 

--- a/parse.h
+++ b/parse.h
@@ -94,6 +94,8 @@ typedef struct s_parse_ast
 	}					content;
 }	t_parse_ast;
 
+t_parse_ast	*parse_new_ast_node(t_parse_ast_type type, void *content);
+
 t_parse_ast	*parse_redirection(t_parse_buffer *buf, t_token *tok);
 t_parse_ast	*parse_string(t_parse_buffer *buf, t_token *tok);
 t_parse_ast	*parse_arguments(t_parse_buffer *buf, t_token *tok);
@@ -103,8 +105,7 @@ t_parse_ast	*parse_delimiter(t_parse_buffer *buf, t_token *tok);
 t_parse_ast	*parse_sequential_commands(t_parse_buffer *buf, t_token *tok);
 t_parse_ast	*parse_command_line(t_parse_buffer *buf, t_token *tok);
 
-void		parse_skip_spaces(t_parse_buffer *buf, t_token *tok);
-
 void		parse_fatal_error(void);
+void		parse_skip_spaces(t_parse_buffer *buf, t_token *tok);
 
 #endif

--- a/parse.h
+++ b/parse.h
@@ -36,8 +36,8 @@ typedef struct s_parse_ast	t_parse_ast;
 
 typedef struct s_parse_node_string
 {
-	const char				*text;
-	t_token_type			type;
+	const char		*text;
+	t_token_type	type;
 	t_parse_ast		*next;
 }	t_parse_node_string;
 
@@ -61,13 +61,13 @@ typedef struct s_parse_node_arguments
 
 typedef struct s_parse_node_redirection
 {
-	t_parse_ast	*string_node;
-	t_token_type		type;
+	t_parse_ast		*string_node;
+	t_token_type	type;
 }	t_parse_node_redirection;
 
 typedef struct s_parse_node_delimiter
 {
-	t_token_type		type;
+	t_token_type	type;
 }	t_parse_node_delimiter;
 
 typedef struct s_parse_node_seqcmds

--- a/parse.h
+++ b/parse.h
@@ -12,12 +12,6 @@ typedef struct s_parse_buffer
 	int		cur_pos;
 }	t_parse_buffer;
 
-typedef enum e_parse_result
-{
-	PARSE_OK = 0xc001,
-	PARSE_KO,
-}	t_parse_result;
-
 typedef enum e_parse_ast_type
 {
 	ASTNODE_NONE = 0xc201,
@@ -100,25 +94,17 @@ typedef struct s_parse_ast
 	}					content;
 }	t_parse_ast;
 
-t_parse_result	parse_redirection(
-					t_parse_buffer *buf, t_parse_ast **node, t_token *tok);
-t_parse_result	parse_string(
-					t_parse_buffer *buf, t_parse_ast **node, t_token *tok);
-t_parse_result	parse_arguments(
-					t_parse_buffer *buf, t_parse_ast **node, t_token *tok);
-t_parse_result	parse_command(
-					t_parse_buffer *buf, t_parse_ast **node, t_token *tok);
-t_parse_result	parse_piped_commands(
-					t_parse_buffer *buf, t_parse_ast **node, t_token *tok);
-t_parse_result	parse_delimiter(
-					t_parse_buffer *buf, t_parse_ast **node, t_token *tok);
-t_parse_result	parse_sequential_commands(
-					t_parse_buffer *buf, t_parse_ast **node, t_token *tok);
-t_parse_result	parse_command_line(
-					t_parse_buffer *buf, t_parse_ast **node, t_token *tok);
+t_parse_ast	*parse_redirection(t_parse_buffer *buf, t_token *tok);
+t_parse_ast	*parse_string(t_parse_buffer *buf, t_token *tok);
+t_parse_ast	*parse_arguments(t_parse_buffer *buf, t_token *tok);
+t_parse_ast	*parse_command(t_parse_buffer *buf, t_token *tok);
+t_parse_ast	*parse_piped_commands(t_parse_buffer *buf, t_token *tok);
+t_parse_ast	*parse_delimiter(t_parse_buffer *buf, t_token *tok);
+t_parse_ast	*parse_sequential_commands(t_parse_buffer *buf, t_token *tok);
+t_parse_ast	*parse_command_line(t_parse_buffer *buf, t_token *tok);
 
-void			parse_skip_spaces(t_parse_buffer *buf, t_token *tok);
+void		parse_skip_spaces(t_parse_buffer *buf, t_token *tok);
 
-void			parse_fatal_error(void);
+void		parse_fatal_error(void);
 
 #endif

--- a/parse1.c
+++ b/parse1.c
@@ -9,8 +9,8 @@
 **	  | sequential_commands "\n"
 */
 
-t_parse_result	parse_command_line(
-	t_parse_buffer *buf, t_parse_ast **node, t_token *tok)
+t_parse_ast	*parse_command_line(
+	t_parse_buffer *buf, t_token *tok)
 {
 	t_parse_ast				*cmdline_node;
 	t_parse_ast				*seqcmd_node;
@@ -38,8 +38,8 @@ t_parse_result	parse_command_line(
 **	  | (bonus) "&"
 */
 
-t_parse_result	parse_delimiter(
-	t_parse_buffer *buf, t_parse_ast **node, t_token *tok)
+t_parse_ast	*parse_delimiter(
+	t_parse_buffer *buf, t_token *tok)
 {
 	t_parse_ast				*delim_node;
 	t_parse_node_delimiter	*content_node;
@@ -63,8 +63,8 @@ t_parse_result	parse_delimiter(
 **	  | (bonus) piped_commands "||" sequential_commands
 */
 
-t_parse_result	parse_sequential_commands(
-	t_parse_buffer *buf, t_parse_ast **node, t_token *tok)
+t_parse_ast	*parse_sequential_commands(
+	t_parse_buffer *buf, t_token *tok)
 {
 	t_parse_ast				*seq_node;
 	t_parse_ast				*pipcmd_node;

--- a/parse1.c
+++ b/parse1.c
@@ -1,6 +1,5 @@
 #include <stdlib.h>
 #include "parse.h"
-#include "parse2.h"
 
 /*
 **command_line ::=

--- a/parse1.c
+++ b/parse1.c
@@ -17,19 +17,18 @@ t_parse_ast	*parse_command_line(
 	t_parse_ast				*delim_node;
 	t_parse_node_cmdline	*content_node;
 
-	if (parse_sequential_commands(buf, &seqcmd_node, tok) != PARSE_OK)
-		return (PARSE_KO);
-	delim_node = NULL;
-	parse_delimiter(buf, &delim_node, tok);
+	seqcmd_node = parse_sequential_commands(buf, tok);
+	if (!seqcmd_node)
+		return (NULL);
+	delim_node = parse_delimiter(buf, tok);
 	parse_skip_spaces(buf, tok);
 	if (tok->type != TOKTYPE_NEWLINE)
-		return (PARSE_KO);
+		return (NULL);
 	content_node = malloc(sizeof(t_parse_node_cmdline));
 	cmdline_node = parse_new_ast_node(ASTNODE_COMMAND_LINE, content_node);
 	content_node->seqcmd_node = seqcmd_node;
 	content_node->delimiter_node = delim_node;
-	*node = cmdline_node;
-	return (PARSE_OK);
+	return (cmdline_node);
 }
 
 /*
@@ -46,12 +45,11 @@ t_parse_ast	*parse_delimiter(
 
 	parse_skip_spaces(buf, tok);
 	if (tok->type != TOKTYPE_SEMICOLON)
-		return (PARSE_KO);
+		return (NULL);
 	content_node = malloc(sizeof(t_parse_node_delimiter));
 	delim_node = parse_new_ast_node(ASTNODE_DELIMITER, content_node);
 	content_node->type = TOKTYPE_SEMICOLON;
-	*node = delim_node;
-	return (PARSE_OK);
+	return (delim_node);
 }
 
 /*
@@ -68,27 +66,24 @@ t_parse_ast	*parse_sequential_commands(
 {
 	t_parse_ast				*seq_node;
 	t_parse_ast				*pipcmd_node;
-	t_parse_ast				*delimiter_node;
-	t_parse_ast				*rest_node;
 	t_parse_node_seqcmds	*content;
 
 	parse_skip_spaces(buf, tok);
-	if (parse_piped_commands(buf, &pipcmd_node, tok) != PARSE_OK)
-		return (PARSE_KO);
+	pipcmd_node = parse_piped_commands(buf, tok);
+	if (!pipcmd_node)
+		return (NULL);
 	content = malloc(sizeof(t_parse_node_seqcmds));
 	seq_node = parse_new_ast_node(ASTNODE_SEQ_COMMANDS, content);
 	content->pipcmd_node = pipcmd_node;
-	content->delimiter_node = NULL;
+	content->delimiter_node = parse_delimiter(buf, tok);
 	content->rest_node = NULL;
-	if (parse_delimiter(buf, &delimiter_node, tok) == PARSE_OK)
+	if (content->delimiter_node)
 	{
 		lex_get_token(buf, tok);
 		parse_skip_spaces(buf, tok);
-		if (parse_sequential_commands(buf, &rest_node, tok) != PARSE_OK)
-			return (PARSE_KO);
-		content->delimiter_node = delimiter_node;
-		content->rest_node = rest_node;
+		content->rest_node = parse_sequential_commands(buf, tok);
+		if (!content->rest_node)
+			return (NULL);
 	}
-	*node = seq_node;
-	return (PARSE_OK);
+	return (seq_node);
 }

--- a/parse1.c
+++ b/parse1.c
@@ -12,9 +12,9 @@
 t_parse_result	parse_command_line(
 	t_parse_buffer *buf, t_parse_ast **node, t_token *tok)
 {
-	t_parse_ast		*cmdline_node;
-	t_parse_ast		*seqcmd_node;
-	t_parse_ast		*delim_node;
+	t_parse_ast				*cmdline_node;
+	t_parse_ast				*seqcmd_node;
+	t_parse_ast				*delim_node;
 	t_parse_node_cmdline	*content_node;
 
 	if (parse_sequential_commands(buf, &seqcmd_node, tok) != PARSE_OK)
@@ -41,7 +41,7 @@ t_parse_result	parse_command_line(
 t_parse_result	parse_delimiter(
 	t_parse_buffer *buf, t_parse_ast **node, t_token *tok)
 {
-	t_parse_ast		*delim_node;
+	t_parse_ast				*delim_node;
 	t_parse_node_delimiter	*content_node;
 
 	parse_skip_spaces(buf, tok);
@@ -66,10 +66,10 @@ t_parse_result	parse_delimiter(
 t_parse_result	parse_sequential_commands(
 	t_parse_buffer *buf, t_parse_ast **node, t_token *tok)
 {
-	t_parse_ast		*seq_node;
-	t_parse_ast		*pipcmd_node;
-	t_parse_ast		*delimiter_node;
-	t_parse_ast		*rest_node;
+	t_parse_ast				*seq_node;
+	t_parse_ast				*pipcmd_node;
+	t_parse_ast				*delimiter_node;
+	t_parse_ast				*rest_node;
 	t_parse_node_seqcmds	*content;
 
 	parse_skip_spaces(buf, tok);

--- a/parse1.c
+++ b/parse1.c
@@ -10,11 +10,11 @@
 */
 
 t_parse_result	parse_command_line(
-	t_parse_buffer *buf, t_parse_ast_node **node, t_token *tok)
+	t_parse_buffer *buf, t_parse_ast **node, t_token *tok)
 {
-	t_parse_ast_node		*cmdline_node;
-	t_parse_ast_node		*seqcmd_node;
-	t_parse_ast_node		*delim_node;
+	t_parse_ast		*cmdline_node;
+	t_parse_ast		*seqcmd_node;
+	t_parse_ast		*delim_node;
 	t_parse_node_cmdline	*content_node;
 
 	if (parse_sequential_commands(buf, &seqcmd_node, tok) != PARSE_OK)
@@ -39,9 +39,9 @@ t_parse_result	parse_command_line(
 */
 
 t_parse_result	parse_delimiter(
-	t_parse_buffer *buf, t_parse_ast_node **node, t_token *tok)
+	t_parse_buffer *buf, t_parse_ast **node, t_token *tok)
 {
-	t_parse_ast_node		*delim_node;
+	t_parse_ast		*delim_node;
 	t_parse_node_delimiter	*content_node;
 
 	parse_skip_spaces(buf, tok);
@@ -64,12 +64,12 @@ t_parse_result	parse_delimiter(
 */
 
 t_parse_result	parse_sequential_commands(
-	t_parse_buffer *buf, t_parse_ast_node **node, t_token *tok)
+	t_parse_buffer *buf, t_parse_ast **node, t_token *tok)
 {
-	t_parse_ast_node		*seq_node;
-	t_parse_ast_node		*pipcmd_node;
-	t_parse_ast_node		*delimiter_node;
-	t_parse_ast_node		*rest_node;
+	t_parse_ast		*seq_node;
+	t_parse_ast		*pipcmd_node;
+	t_parse_ast		*delimiter_node;
+	t_parse_ast		*rest_node;
 	t_parse_node_seqcmds	*content;
 
 	parse_skip_spaces(buf, tok);

--- a/parse2.c
+++ b/parse2.c
@@ -16,8 +16,9 @@ t_parse_ast	*parse_piped_commands(t_parse_buffer *buf, t_token *tok)
 	t_parse_ast				*cmd_node;
 	t_parse_ast				*rest_node;
 
-	if (parse_command(buf, &cmd_node, tok) != PARSE_OK)
-		return (PARSE_KO);
+	cmd_node = parse_command(buf, tok);
+	if (!cmd_node)
+		return (NULL);
 	content_node = malloc(sizeof(t_parse_node_pipcmds));
 	pip_node = parse_new_ast_node(ASTNODE_PIPED_COMMANDS, content_node);
 	content_node->command_node = cmd_node;
@@ -27,12 +28,12 @@ t_parse_ast	*parse_piped_commands(t_parse_buffer *buf, t_token *tok)
 	{
 		lex_get_token(buf, tok);
 		parse_skip_spaces(buf, tok);
-		if (parse_piped_commands(buf, &rest_node, tok) != PARSE_OK)
-			return (PARSE_KO);
+		rest_node = parse_piped_commands(buf, tok);
+		if (!rest_node)
+			return (NULL);
 	}
 	content_node->next = rest_node;
-	*node = pip_node;
-	return (PARSE_OK);
+	return (pip_node);
 }
 
 /*
@@ -42,20 +43,19 @@ t_parse_ast	*parse_piped_commands(t_parse_buffer *buf, t_token *tok)
 **	  | (bonus) "(" sequential_commands delimiter ")"
 */
 
-t_parse_ast	*parse_command(
-	t_parse_buffer *buf, t_token *tok)
+t_parse_ast	*parse_command(t_parse_buffer *buf, t_token *tok)
 {
 	t_parse_ast				*cmd_node;
 	t_parse_node_command	*content_node;
 	t_parse_ast				*args_node;
 
-	if (parse_arguments(buf, &args_node, tok) != PARSE_OK)
-		return (PARSE_KO);
+	args_node = parse_arguments(buf, tok);
+	if (!args_node)
+		return (NULL);
 	content_node = malloc(sizeof(t_parse_node_command));
 	cmd_node = parse_new_ast_node(ASTNODE_COMMAND, content_node);
 	content_node->arguments_node = args_node;
-	*node = cmd_node;
-	return (PARSE_OK);
+	return (cmd_node);
 }
 
 /*
@@ -66,8 +66,7 @@ t_parse_ast	*parse_command(
 **	  | string arguments
 */
 
-t_parse_ast	*parse_arguments(
-	t_parse_buffer *buf, t_token *tok)
+t_parse_ast	*parse_arguments(t_parse_buffer *buf, t_token *tok)
 {
 	t_parse_ast				*string_node;
 	t_parse_ast				*redirection_node;
@@ -75,21 +74,19 @@ t_parse_ast	*parse_arguments(
 	t_parse_node_arguments	*content_node;
 	t_parse_ast				*args_node;
 
-	string_node = NULL;
-	redirection_node = NULL;
 	rest_node = NULL;
 	parse_skip_spaces(buf, tok);
-	if (!(parse_redirection(buf, &redirection_node, tok) == PARSE_OK)
-		&& !(parse_string(buf, &string_node, tok) == PARSE_OK))
-		return (PARSE_KO);
-	parse_arguments(buf, &rest_node, tok);
+	redirection_node = parse_redirection(buf, tok);
+	string_node = parse_string(buf, tok);
+	if (!redirection_node && !string_node)
+		return (NULL);
+	rest_node = parse_arguments(buf, tok);
 	content_node = malloc(sizeof(t_parse_node_arguments));
+	args_node = parse_new_ast_node(ASTNODE_ARGUMENTS, content_node);
 	content_node->string_node = string_node;
 	content_node->redirection_node = redirection_node;
 	content_node->rest_node = rest_node;
-	args_node = parse_new_ast_node(ASTNODE_ARGUMENTS, content_node);
-	*node = args_node;
-	return (PARSE_OK);
+	return (args_node);
 }
 
 /*
@@ -101,16 +98,14 @@ t_parse_ast	*parse_arguments(
 **	  | expandable_quoted <no_space> string
 **	  | expandable_quoted
 */
-t_parse_ast	*parse_string(
-	t_parse_buffer *buf, t_token *tok)
+t_parse_ast	*parse_string(t_parse_buffer *buf, t_token *tok)
 {
 	t_parse_ast			*new_node;
 	t_parse_node_string	*string;
 	char				*text;
 
 	if (tok->type != TOKTYPE_EXPANDABLE)
-		return (PARSE_KO);
-	string = NULL;
+		return (NULL);
 	string = malloc(sizeof(t_parse_node_string));
 	new_node = parse_new_ast_node(ASTNODE_STRING, string);
 	text = malloc(tok->length + 1);
@@ -121,9 +116,8 @@ t_parse_ast	*parse_string(
 	text[tok->length] = '\0';
 	string->text = text;
 	lex_get_token(buf, tok);
-	parse_string(buf, &string->next, tok);
-	*node = new_node;
-	return (PARSE_OK);
+	string->next = parse_string(buf, tok);
+	return (new_node);
 }
 
 /*
@@ -140,17 +134,17 @@ t_parse_ast	*parse_redirection(
 	t_parse_node_redirection	*redirection;
 
 	if (tok->type != TOKTYPE_INPUT_REDIRECTION)
-		return (PARSE_KO);
+		return (NULL);
 	lex_get_token(buf, tok);
 	parse_skip_spaces(buf, tok);
-	if (parse_string(buf, &str_node, tok) == PARSE_OK)
+	str_node = parse_string(buf, tok);
+	if (str_node)
 	{
 		redirection = malloc(sizeof(t_parse_node_redirection));
 		redirection->type = TOKTYPE_INPUT_REDIRECTION;
 		redirection->string_node = str_node;
 		new_node = parse_new_ast_node(ASTNODE_REDIRECTION, redirection);
-		*node = new_node;
-		return (PARSE_OK);
+		return (new_node);
 	}
-	return (PARSE_KO);
+	return (NULL);
 }

--- a/parse2.c
+++ b/parse2.c
@@ -10,12 +10,12 @@
 */
 
 t_parse_result	parse_piped_commands(
-	t_parse_buffer *buf, t_parse_ast_node **node, t_token *tok)
+	t_parse_buffer *buf, t_parse_ast **node, t_token *tok)
 {
-	t_parse_ast_node		*pip_node;
+	t_parse_ast		*pip_node;
 	t_parse_node_pipcmds	*content_node;
-	t_parse_ast_node		*cmd_node;
-	t_parse_ast_node		*rest_node;
+	t_parse_ast		*cmd_node;
+	t_parse_ast		*rest_node;
 
 	if (parse_command(buf, &cmd_node, tok) != PARSE_OK)
 		return (PARSE_KO);
@@ -44,11 +44,11 @@ t_parse_result	parse_piped_commands(
 */
 
 t_parse_result	parse_command(
-	t_parse_buffer *buf, t_parse_ast_node **node, t_token *tok)
+	t_parse_buffer *buf, t_parse_ast **node, t_token *tok)
 {
-	t_parse_ast_node		*cmd_node;
+	t_parse_ast		*cmd_node;
 	t_parse_node_command	*content_node;
-	t_parse_ast_node		*args_node;
+	t_parse_ast		*args_node;
 
 	if (parse_arguments(buf, &args_node, tok) != PARSE_OK)
 		return (PARSE_KO);
@@ -68,13 +68,13 @@ t_parse_result	parse_command(
 */
 
 t_parse_result	parse_arguments(
-	t_parse_buffer *buf, t_parse_ast_node **node, t_token *tok)
+	t_parse_buffer *buf, t_parse_ast **node, t_token *tok)
 {
-	t_parse_ast_node		*string_node;
-	t_parse_ast_node		*redirection_node;
-	t_parse_ast_node		*rest_node;
+	t_parse_ast		*string_node;
+	t_parse_ast		*redirection_node;
+	t_parse_ast		*rest_node;
 	t_parse_node_arguments	*content_node;
-	t_parse_ast_node		*args_node;
+	t_parse_ast		*args_node;
 
 	string_node = NULL;
 	redirection_node = NULL;
@@ -103,9 +103,9 @@ t_parse_result	parse_arguments(
 **	  | expandable_quoted
 */
 t_parse_result	parse_string(
-	t_parse_buffer *buf, t_parse_ast_node **node, t_token *tok)
+	t_parse_buffer *buf, t_parse_ast **node, t_token *tok)
 {
-	t_parse_ast_node	*new_node;
+	t_parse_ast	*new_node;
 	t_parse_node_string	*string;
 	char				*text;
 
@@ -134,10 +134,10 @@ t_parse_result	parse_string(
 **	  | ">>" string
 */
 t_parse_result	parse_redirection(
-	t_parse_buffer *buf, t_parse_ast_node **node, t_token *tok)
+	t_parse_buffer *buf, t_parse_ast **node, t_token *tok)
 {
-	t_parse_ast_node			*new_node;
-	t_parse_ast_node			*str_node;
+	t_parse_ast			*new_node;
+	t_parse_ast			*str_node;
 	t_parse_node_redirection	*redirection;
 
 	if (tok->type != TOKTYPE_INPUT_REDIRECTION)

--- a/parse2.c
+++ b/parse2.c
@@ -9,8 +9,7 @@
 **	  | command
 */
 
-t_parse_result	parse_piped_commands(
-	t_parse_buffer *buf, t_parse_ast **node, t_token *tok)
+t_parse_ast	*parse_piped_commands(t_parse_buffer *buf, t_token *tok)
 {
 	t_parse_ast				*pip_node;
 	t_parse_node_pipcmds	*content_node;
@@ -43,8 +42,8 @@ t_parse_result	parse_piped_commands(
 **	  | (bonus) "(" sequential_commands delimiter ")"
 */
 
-t_parse_result	parse_command(
-	t_parse_buffer *buf, t_parse_ast **node, t_token *tok)
+t_parse_ast	*parse_command(
+	t_parse_buffer *buf, t_token *tok)
 {
 	t_parse_ast				*cmd_node;
 	t_parse_node_command	*content_node;
@@ -67,8 +66,8 @@ t_parse_result	parse_command(
 **	  | string arguments
 */
 
-t_parse_result	parse_arguments(
-	t_parse_buffer *buf, t_parse_ast **node, t_token *tok)
+t_parse_ast	*parse_arguments(
+	t_parse_buffer *buf, t_token *tok)
 {
 	t_parse_ast				*string_node;
 	t_parse_ast				*redirection_node;
@@ -102,8 +101,8 @@ t_parse_result	parse_arguments(
 **	  | expandable_quoted <no_space> string
 **	  | expandable_quoted
 */
-t_parse_result	parse_string(
-	t_parse_buffer *buf, t_parse_ast **node, t_token *tok)
+t_parse_ast	*parse_string(
+	t_parse_buffer *buf, t_token *tok)
 {
 	t_parse_ast			*new_node;
 	t_parse_node_string	*string;
@@ -133,8 +132,8 @@ t_parse_result	parse_string(
 **	  | ">" string
 **	  | ">>" string
 */
-t_parse_result	parse_redirection(
-	t_parse_buffer *buf, t_parse_ast **node, t_token *tok)
+t_parse_ast	*parse_redirection(
+	t_parse_buffer *buf, t_token *tok)
 {
 	t_parse_ast					*new_node;
 	t_parse_ast					*str_node;

--- a/parse2.c
+++ b/parse2.c
@@ -12,10 +12,10 @@
 t_parse_result	parse_piped_commands(
 	t_parse_buffer *buf, t_parse_ast **node, t_token *tok)
 {
-	t_parse_ast		*pip_node;
+	t_parse_ast				*pip_node;
 	t_parse_node_pipcmds	*content_node;
-	t_parse_ast		*cmd_node;
-	t_parse_ast		*rest_node;
+	t_parse_ast				*cmd_node;
+	t_parse_ast				*rest_node;
 
 	if (parse_command(buf, &cmd_node, tok) != PARSE_OK)
 		return (PARSE_KO);
@@ -46,9 +46,9 @@ t_parse_result	parse_piped_commands(
 t_parse_result	parse_command(
 	t_parse_buffer *buf, t_parse_ast **node, t_token *tok)
 {
-	t_parse_ast		*cmd_node;
+	t_parse_ast				*cmd_node;
 	t_parse_node_command	*content_node;
-	t_parse_ast		*args_node;
+	t_parse_ast				*args_node;
 
 	if (parse_arguments(buf, &args_node, tok) != PARSE_OK)
 		return (PARSE_KO);
@@ -70,11 +70,11 @@ t_parse_result	parse_command(
 t_parse_result	parse_arguments(
 	t_parse_buffer *buf, t_parse_ast **node, t_token *tok)
 {
-	t_parse_ast		*string_node;
-	t_parse_ast		*redirection_node;
-	t_parse_ast		*rest_node;
+	t_parse_ast				*string_node;
+	t_parse_ast				*redirection_node;
+	t_parse_ast				*rest_node;
 	t_parse_node_arguments	*content_node;
-	t_parse_ast		*args_node;
+	t_parse_ast				*args_node;
 
 	string_node = NULL;
 	redirection_node = NULL;
@@ -105,7 +105,7 @@ t_parse_result	parse_arguments(
 t_parse_result	parse_string(
 	t_parse_buffer *buf, t_parse_ast **node, t_token *tok)
 {
-	t_parse_ast	*new_node;
+	t_parse_ast			*new_node;
 	t_parse_node_string	*string;
 	char				*text;
 
@@ -136,8 +136,8 @@ t_parse_result	parse_string(
 t_parse_result	parse_redirection(
 	t_parse_buffer *buf, t_parse_ast **node, t_token *tok)
 {
-	t_parse_ast			*new_node;
-	t_parse_ast			*str_node;
+	t_parse_ast					*new_node;
+	t_parse_ast					*str_node;
 	t_parse_node_redirection	*redirection;
 
 	if (tok->type != TOKTYPE_INPUT_REDIRECTION)

--- a/parse2.c
+++ b/parse2.c
@@ -1,7 +1,6 @@
 #include <stdlib.h>
 #include "libft/libft.h"
 #include "parse.h"
-#include "parse2.h"
 
 /*
 **piped_commands ::=

--- a/parse2.h
+++ b/parse2.h
@@ -2,6 +2,6 @@
 # define PARSE2_H
 
 t_parse_ast	*parse_new_ast_node(t_parse_ast_type type, void *content);
-void				parse_skip_spaces(t_parse_buffer *buf, t_token *tok);
+void		parse_skip_spaces(t_parse_buffer *buf, t_token *tok);
 
 #endif

--- a/parse2.h
+++ b/parse2.h
@@ -1,7 +1,0 @@
-#ifndef PARSE2_H
-# define PARSE2_H
-
-t_parse_ast	*parse_new_ast_node(t_parse_ast_type type, void *content);
-void		parse_skip_spaces(t_parse_buffer *buf, t_token *tok);
-
-#endif

--- a/parse2.h
+++ b/parse2.h
@@ -1,7 +1,7 @@
 #ifndef PARSE2_H
 # define PARSE2_H
 
-t_parse_ast_node	*parse_new_ast_node(t_parse_ast_type type, void *content);
+t_parse_ast	*parse_new_ast_node(t_parse_ast_type type, void *content);
 void				parse_skip_spaces(t_parse_buffer *buf, t_token *tok);
 
 #endif

--- a/parse_utils.c
+++ b/parse_utils.c
@@ -11,13 +11,13 @@ void	parse_skip_spaces(t_parse_buffer *buf, t_token *tok)
 	}
 }
 
-t_parse_ast_node	*parse_new_ast_node(t_parse_ast_type type, void *content)
+t_parse_ast	*parse_new_ast_node(t_parse_ast_type type, void *content)
 {
-	t_parse_ast_node	*dest;
+	t_parse_ast	*dest;
 
 	if (!(type > ASTNODE_NONE && type < ASTNODE_INVALID))
 		parse_fatal_error();
-	dest = malloc(sizeof(t_parse_ast_node));
+	dest = malloc(sizeof(t_parse_ast));
 	if (!dest || !content)
 		parse_fatal_error();
 	dest->type = type;

--- a/test/parse_test.c
+++ b/test/parse_test.c
@@ -131,20 +131,20 @@ void test_lexer()
 	}
 }
 
-void check_string(t_parse_ast_node *node, const char *expected)
+void check_string(t_parse_ast *node, const char *expected)
 {
     CHECK_EQ(node->type, ASTNODE_STRING);
     CHECK_EQ_STR(node->content.string->text, expected);
 }
 
-void check_single_argument(t_parse_ast_node *node, const char *expected)
+void check_single_argument(t_parse_ast *node, const char *expected)
 {
-    t_parse_ast_node *str_node = node->content.arguments->string_node;
+    t_parse_ast *str_node = node->content.arguments->string_node;
     CHECK(str_node);
     check_string(str_node, expected);
 }
 
-void check_args(t_parse_ast_node	*node)
+void check_args(t_parse_ast	*node)
 {
     CHECK(node);
     CHECK_EQ(node->type, ASTNODE_ARGUMENTS);
@@ -152,19 +152,19 @@ void check_args(t_parse_ast_node	*node)
     check_single_argument(node, "file");
 
     node = node->content.arguments->rest_node;
-    t_parse_ast_node *red_node = node->content.arguments->redirection_node;
+    t_parse_ast *red_node = node->content.arguments->redirection_node;
     CHECK(red_node);
     CHECK_EQ(red_node->type, ASTNODE_REDIRECTION);
     CHECK_EQ(red_node->content.redirection->type, TOKTYPE_INPUT_REDIRECTION);
     check_string(red_node->content.redirection->string_node, "abc");
 }
 
-void check_piped_commands(t_parse_ast_node *node)
+void check_piped_commands(t_parse_ast *node)
 {
     CHECK_EQ(node->type, ASTNODE_PIPED_COMMANDS);
     CHECK(node->content.piped_commands->command_node);
     CHECK(node->content.piped_commands->next);
-    t_parse_ast_node *next = node->content.piped_commands->next;
+    t_parse_ast *next = node->content.piped_commands->next;
     CHECK_EQ(next->type, ASTNODE_PIPED_COMMANDS);
     CHECK(next->content.piped_commands->command_node);
     check_args(next->content.piped_commands->command_node
@@ -172,13 +172,13 @@ void check_piped_commands(t_parse_ast_node *node)
     CHECK(!next->content.piped_commands->next);
 }
 
-void check_delimiter(t_parse_ast_node *node)
+void check_delimiter(t_parse_ast *node)
 {
     CHECK_EQ(node->type, ASTNODE_DELIMITER);
     CHECK_EQ(node->content.delimiter->type, TOKTYPE_SEMICOLON);
 }
 
-void check_piped_seqence(t_parse_ast_node *node)
+void check_piped_seqence(t_parse_ast *node)
 {
     check_piped_commands(node->content.sequential_commands->pipcmd_node);
     check_delimiter(
@@ -201,7 +201,7 @@ void test_parser(void)
 	{
 		t_parse_buffer	buf;
 		init_buf_with_string(&buf, "file\n");
-		t_parse_ast_node	*node;
+		t_parse_ast	*node;
 		t_token	tok;
 
 		lex_get_token(&buf, &tok);
@@ -219,7 +219,7 @@ void test_parser(void)
 	{
 		t_parse_buffer	buf;
 		init_buf_with_string(&buf, "< file\n");
-		t_parse_ast_node	*node = NULL;
+		t_parse_ast	*node = NULL;
 		t_token	tok;
 
 		lex_get_token(&buf, &tok);
@@ -237,7 +237,7 @@ void test_parser(void)
 	{
 		t_parse_buffer	buf;
 		init_buf_with_string(&buf, "abc \n");
-		t_parse_ast_node	*node = NULL;
+		t_parse_ast	*node = NULL;
 		t_token	tok;
 
 		lex_get_token(&buf, &tok);
@@ -246,7 +246,7 @@ void test_parser(void)
 		CHECK_EQ(ret, PARSE_OK);
 		CHECK(node);
 		CHECK_EQ(node->type, ASTNODE_ARGUMENTS);
-		t_parse_ast_node *str_node = node->content.arguments->string_node;
+		t_parse_ast *str_node = node->content.arguments->string_node;
 		CHECK(str_node);
 		CHECK_EQ(str_node->type, ASTNODE_STRING);
 		CHECK_EQ_STR(str_node->content.string->text, "abc");
@@ -256,7 +256,7 @@ void test_parser(void)
 	{
 		t_parse_buffer	buf;
 		init_buf_with_string(&buf, "abc\n");
-		t_parse_ast_node	*node = NULL;
+		t_parse_ast	*node = NULL;
 		t_token	tok;
 
 		lex_get_token(&buf, &tok);
@@ -265,7 +265,7 @@ void test_parser(void)
 		CHECK_EQ(ret, PARSE_OK);
 		CHECK(node);
 		CHECK_EQ(node->type, ASTNODE_ARGUMENTS);
-		t_parse_ast_node *str_node = node->content.arguments->string_node;
+		t_parse_ast *str_node = node->content.arguments->string_node;
 		CHECK(str_node);
 		CHECK_EQ(str_node->type, ASTNODE_STRING);
 		CHECK_EQ_STR(str_node->content.string->text, "abc");
@@ -275,7 +275,7 @@ void test_parser(void)
 	{
 		t_parse_buffer	buf;
 		init_buf_with_string(&buf, "abc def \n");
-		t_parse_ast_node	*node = NULL;
+		t_parse_ast	*node = NULL;
 		t_token	tok;
 
 		lex_get_token(&buf, &tok);
@@ -284,12 +284,12 @@ void test_parser(void)
 		CHECK_EQ(ret, PARSE_OK);
 		CHECK(node);
 		CHECK_EQ(node->type, ASTNODE_ARGUMENTS);
-		t_parse_ast_node *str_node = node->content.arguments->string_node;
+		t_parse_ast *str_node = node->content.arguments->string_node;
 		CHECK(str_node);
 		CHECK_EQ(str_node->type, ASTNODE_STRING);
 		CHECK_EQ_STR(str_node->content.string->text, "abc");
 
-		t_parse_ast_node *rest_node = node->content.arguments->rest_node;
+		t_parse_ast *rest_node = node->content.arguments->rest_node;
 
 		CHECK_EQ(rest_node->type, ASTNODE_ARGUMENTS);
 		str_node = rest_node->content.arguments->string_node;
@@ -302,7 +302,7 @@ void test_parser(void)
 	{
 		t_parse_buffer	buf;
 		init_buf_with_string(&buf, "< abc \n");
-		t_parse_ast_node	*node = NULL;
+		t_parse_ast	*node = NULL;
 		t_token	tok;
 
 		lex_get_token(&buf, &tok);
@@ -312,7 +312,7 @@ void test_parser(void)
 		CHECK(node);
 		CHECK_EQ(node->type, ASTNODE_ARGUMENTS);
 
-		t_parse_ast_node *red_node = node->content.arguments->redirection_node;
+		t_parse_ast *red_node = node->content.arguments->redirection_node;
 		CHECK(red_node);
 		CHECK_EQ(red_node->type, ASTNODE_REDIRECTION);
 		CHECK_EQ(red_node->content.redirection->type, TOKTYPE_INPUT_REDIRECTION);
@@ -324,7 +324,7 @@ void test_parser(void)
 	{
 		t_parse_buffer	buf;
 		init_buf_with_string(&buf, "file < abc \n");
-		t_parse_ast_node	*node = NULL;
+		t_parse_ast	*node = NULL;
 		t_token	tok;
 
 		lex_get_token(&buf, &tok);
@@ -338,7 +338,7 @@ void test_parser(void)
 	{
 		t_parse_buffer	buf;
 		init_buf_with_string(&buf, "file < abc \n");
-		t_parse_ast_node	*node = NULL;
+		t_parse_ast	*node = NULL;
 		t_token	tok;
 
 		lex_get_token(&buf, &tok);
@@ -353,7 +353,7 @@ void test_parser(void)
 	{
 		t_parse_buffer	buf;
 		init_buf_with_string(&buf, "abc \n");
-		t_parse_ast_node	*node = NULL;
+		t_parse_ast	*node = NULL;
 		t_token	tok;
 
 		lex_get_token(&buf, &tok);
@@ -362,10 +362,10 @@ void test_parser(void)
         CHECK_EQ(ret, PARSE_OK);
         CHECK_EQ(node->type, ASTNODE_PIPED_COMMANDS);
 
-		t_parse_ast_node *cmd = node->content.piped_commands->command_node;
+		t_parse_ast *cmd = node->content.piped_commands->command_node;
 		CHECK(cmd);
 		CHECK_EQ(cmd->type, ASTNODE_COMMAND);
-		t_parse_ast_node *str = cmd->content.command->arguments_node
+		t_parse_ast *str = cmd->content.command->arguments_node
 			->content.arguments->string_node;
 		CHECK(str);
 		CHECK_EQ_STR(str->content.string->text, "abc");
@@ -376,7 +376,7 @@ void test_parser(void)
 	{
 		t_parse_buffer	buf;
 		init_buf_with_string(&buf, "abc | file < abc \n");
-		t_parse_ast_node	*node = NULL;
+		t_parse_ast	*node = NULL;
 		t_token	tok;
 
 		lex_get_token(&buf, &tok);
@@ -390,7 +390,7 @@ void test_parser(void)
 	{
 		t_parse_buffer	buf;
 		init_buf_with_string(&buf, "; \n");
-		t_parse_ast_node	*node = NULL;
+		t_parse_ast	*node = NULL;
 		t_token	tok;
 
 		lex_get_token(&buf, &tok);
@@ -403,7 +403,7 @@ void test_parser(void)
     {
 		t_parse_buffer	buf;
 		init_buf_with_string(&buf, " abc ; xyz \n");
-		t_parse_ast_node	*node = NULL;
+		t_parse_ast	*node = NULL;
 		t_token	tok;
 
 		lex_get_token(&buf, &tok);
@@ -431,7 +431,7 @@ void test_parser(void)
     {
 		t_parse_buffer	buf;
 		init_buf_with_string(&buf, " abc | file < abc ; xyz \n");
-		t_parse_ast_node	*node = NULL;
+		t_parse_ast	*node = NULL;
 		t_token	tok;
 
 		lex_get_token(&buf, &tok);
@@ -445,7 +445,7 @@ void test_parser(void)
 	{
 		t_parse_buffer	buf;
 		init_buf_with_string(&buf, "abc\n");
-		t_parse_ast_node	*node = NULL;
+		t_parse_ast	*node = NULL;
 		t_token	tok;
 
 		lex_get_token(&buf, &tok);
@@ -464,7 +464,7 @@ void test_parser(void)
     {
 		t_parse_buffer	buf;
 		init_buf_with_string(&buf, " abc | file < abc ; xyz \n");
-		t_parse_ast_node	*node = NULL;
+		t_parse_ast	*node = NULL;
 		t_token	tok;
 
 		lex_get_token(&buf, &tok);

--- a/test/parse_test.c
+++ b/test/parse_test.c
@@ -201,13 +201,11 @@ void test_parser(void)
 	{
 		t_parse_buffer	buf;
 		init_buf_with_string(&buf, "file\n");
-		t_parse_ast	*node;
 		t_token	tok;
 
 		lex_get_token(&buf, &tok);
 
-		int ret = parse_string(&buf, &node, &tok);
-		CHECK_EQ(ret, PARSE_OK);
+		t_parse_ast *node = parse_string(&buf, &tok);
 		CHECK(node);
 		CHECK_EQ(node->type, ASTNODE_STRING);
 		CHECK_EQ(node->content.string->type, TOKTYPE_EXPANDABLE);
@@ -219,13 +217,11 @@ void test_parser(void)
 	{
 		t_parse_buffer	buf;
 		init_buf_with_string(&buf, "< file\n");
-		t_parse_ast	*node = NULL;
 		t_token	tok;
 
 		lex_get_token(&buf, &tok);
 
-		int ret = parse_redirection(&buf, &node, &tok);
-		CHECK_EQ(ret, PARSE_OK);
+		t_parse_ast *node = parse_redirection(&buf, &tok);
 		CHECK(node);
 		CHECK_EQ(node->type, ASTNODE_REDIRECTION);
 		CHECK_EQ(node->content.redirection->type, TOKTYPE_INPUT_REDIRECTION);
@@ -237,13 +233,11 @@ void test_parser(void)
 	{
 		t_parse_buffer	buf;
 		init_buf_with_string(&buf, "abc \n");
-		t_parse_ast	*node = NULL;
 		t_token	tok;
 
 		lex_get_token(&buf, &tok);
 
-		int ret = parse_arguments(&buf, &node, &tok);
-		CHECK_EQ(ret, PARSE_OK);
+		t_parse_ast *node = parse_arguments(&buf, &tok);
 		CHECK(node);
 		CHECK_EQ(node->type, ASTNODE_ARGUMENTS);
 		t_parse_ast *str_node = node->content.arguments->string_node;
@@ -256,13 +250,11 @@ void test_parser(void)
 	{
 		t_parse_buffer	buf;
 		init_buf_with_string(&buf, "abc\n");
-		t_parse_ast	*node = NULL;
 		t_token	tok;
 
 		lex_get_token(&buf, &tok);
 
-		int ret = parse_arguments(&buf, &node, &tok);
-		CHECK_EQ(ret, PARSE_OK);
+		t_parse_ast *node = parse_arguments(&buf, &tok);
 		CHECK(node);
 		CHECK_EQ(node->type, ASTNODE_ARGUMENTS);
 		t_parse_ast *str_node = node->content.arguments->string_node;
@@ -275,13 +267,11 @@ void test_parser(void)
 	{
 		t_parse_buffer	buf;
 		init_buf_with_string(&buf, "abc def \n");
-		t_parse_ast	*node = NULL;
 		t_token	tok;
 
 		lex_get_token(&buf, &tok);
 
-		int ret = parse_arguments(&buf, &node, &tok);
-		CHECK_EQ(ret, PARSE_OK);
+		t_parse_ast *node = parse_arguments(&buf, &tok);
 		CHECK(node);
 		CHECK_EQ(node->type, ASTNODE_ARGUMENTS);
 		t_parse_ast *str_node = node->content.arguments->string_node;
@@ -302,13 +292,11 @@ void test_parser(void)
 	{
 		t_parse_buffer	buf;
 		init_buf_with_string(&buf, "< abc \n");
-		t_parse_ast	*node = NULL;
 		t_token	tok;
 
 		lex_get_token(&buf, &tok);
 
-		int ret = parse_arguments(&buf, &node, &tok);
-		CHECK_EQ(ret, PARSE_OK);
+		t_parse_ast *node = parse_arguments(&buf, &tok);
 		CHECK(node);
 		CHECK_EQ(node->type, ASTNODE_ARGUMENTS);
 
@@ -324,13 +312,11 @@ void test_parser(void)
 	{
 		t_parse_buffer	buf;
 		init_buf_with_string(&buf, "file < abc \n");
-		t_parse_ast	*node = NULL;
 		t_token	tok;
 
 		lex_get_token(&buf, &tok);
 
-		int ret = parse_arguments(&buf, &node, &tok);
-        CHECK_EQ(ret, PARSE_OK);
+		t_parse_ast *node = parse_arguments(&buf, &tok);
         check_args(node);
 	}
 
@@ -338,13 +324,11 @@ void test_parser(void)
 	{
 		t_parse_buffer	buf;
 		init_buf_with_string(&buf, "file < abc \n");
-		t_parse_ast	*node = NULL;
 		t_token	tok;
 
 		lex_get_token(&buf, &tok);
 
-		int ret = parse_command(&buf, &node, &tok);
-        CHECK_EQ(ret, PARSE_OK);
+		t_parse_ast *node = parse_command(&buf, &tok);
         CHECK_EQ(node->type, ASTNODE_COMMAND);
         check_args(node->content.command->arguments_node);
 	}
@@ -353,13 +337,11 @@ void test_parser(void)
 	{
 		t_parse_buffer	buf;
 		init_buf_with_string(&buf, "abc \n");
-		t_parse_ast	*node = NULL;
 		t_token	tok;
 
 		lex_get_token(&buf, &tok);
 
-		int ret = parse_piped_commands(&buf, &node, &tok);
-        CHECK_EQ(ret, PARSE_OK);
+		t_parse_ast *node = parse_piped_commands(&buf, &tok);
         CHECK_EQ(node->type, ASTNODE_PIPED_COMMANDS);
 
 		t_parse_ast *cmd = node->content.piped_commands->command_node;
@@ -376,13 +358,11 @@ void test_parser(void)
 	{
 		t_parse_buffer	buf;
 		init_buf_with_string(&buf, "abc | file < abc \n");
-		t_parse_ast	*node = NULL;
 		t_token	tok;
 
 		lex_get_token(&buf, &tok);
 
-		int ret = parse_piped_commands(&buf, &node, &tok);
-        CHECK_EQ(ret, PARSE_OK);
+		t_parse_ast *node = parse_piped_commands(&buf, &tok);
         check_piped_commands(node);
 	}
 
@@ -390,12 +370,10 @@ void test_parser(void)
 	{
 		t_parse_buffer	buf;
 		init_buf_with_string(&buf, "; \n");
-		t_parse_ast	*node = NULL;
 		t_token	tok;
 
 		lex_get_token(&buf, &tok);
-		int ret = parse_delimiter(&buf, &node, &tok);
-        CHECK_EQ(ret, PARSE_OK);
+		t_parse_ast *node = parse_delimiter(&buf, &tok);
         check_delimiter(node);
 	}
 
@@ -403,12 +381,10 @@ void test_parser(void)
     {
 		t_parse_buffer	buf;
 		init_buf_with_string(&buf, " abc ; xyz \n");
-		t_parse_ast	*node = NULL;
 		t_token	tok;
 
 		lex_get_token(&buf, &tok);
-		int ret = parse_sequential_commands(&buf, &node, &tok);
-        CHECK_EQ(ret, PARSE_OK);
+		t_parse_ast *node = parse_sequential_commands(&buf, &tok);
         check_single_argument(
             node->content.sequential_commands
             ->pipcmd_node->content.piped_commands
@@ -431,12 +407,10 @@ void test_parser(void)
     {
 		t_parse_buffer	buf;
 		init_buf_with_string(&buf, " abc | file < abc ; xyz \n");
-		t_parse_ast	*node = NULL;
 		t_token	tok;
 
 		lex_get_token(&buf, &tok);
-		int ret = parse_sequential_commands(&buf, &node, &tok);
-        CHECK_EQ(ret, PARSE_OK);
+		t_parse_ast *node = parse_sequential_commands(&buf, &tok);
 
         check_piped_seqence(node);
     }
@@ -445,12 +419,10 @@ void test_parser(void)
 	{
 		t_parse_buffer	buf;
 		init_buf_with_string(&buf, "abc\n");
-		t_parse_ast	*node = NULL;
 		t_token	tok;
 
 		lex_get_token(&buf, &tok);
-		int ret = parse_command_line(&buf, &node, &tok);
-		CHECK_EQ(ret, PARSE_OK);
+		t_parse_ast *node = parse_command_line(&buf, &tok);
 		check_single_argument(
 			node->content.command_line->seqcmd_node
 			->content.sequential_commands
@@ -464,12 +436,10 @@ void test_parser(void)
     {
 		t_parse_buffer	buf;
 		init_buf_with_string(&buf, " abc | file < abc ; xyz \n");
-		t_parse_ast	*node = NULL;
 		t_token	tok;
 
 		lex_get_token(&buf, &tok);
-		int ret = parse_command_line(&buf, &node, &tok);
-        CHECK_EQ(ret, PARSE_OK);
+		t_parse_ast *node = parse_command_line(&buf, &tok);
 
         check_piped_seqence(node->content.command_line->seqcmd_node);
         CHECK_EQ(node->content.command_line->delimiter_node, NULL);


### PR DESCRIPTION
いくつか非互換な変更をしました。

- AST の構造体名を `t_parse_ast` に変更
- `parse_sequential_commands` などの各構文要素のパーサ関数が AST のポインタを返すように変更し、`PARSE_OK` と `PARSE_KO` を廃止

AST から `t_command_invocation` へ変換する関数を作るときは、上記の構造体名の変更に気をつけてください。 🙇🏽 