### PR TITLE
> と >> のパーサ

### DIFF
--- a/parse2.c
+++ b/parse2.c
@@ -131,8 +131,12 @@ t_parse_ast	*parse_redirection(
 	t_parse_ast					*new_node;
 	t_parse_ast					*str_node;
 	t_parse_node_redirection	*redirection;
+	t_token_type				type;
 
-	if (tok->type != TOKTYPE_INPUT_REDIRECTION)
+	type = tok->type;
+	if (type != TOKTYPE_INPUT_REDIRECTION
+		&& type != TOKTYPE_OUTPUT_REDIRECTION
+		&& type != TOKTYPE_OUTPUT_APPENDING)
 		return (NULL);
 	lex_get_token(buf, tok);
 	parse_skip_spaces(buf, tok);
@@ -140,7 +144,7 @@ t_parse_ast	*parse_redirection(
 	if (str_node)
 	{
 		redirection = malloc(sizeof(t_parse_node_redirection));
-		redirection->type = TOKTYPE_INPUT_REDIRECTION;
+		redirection->type = type;
 		redirection->string_node = str_node;
 		new_node = parse_new_ast_node(ASTNODE_REDIRECTION, redirection);
 		return (new_node);

--- a/test/parse_test.c
+++ b/test/parse_test.c
@@ -229,6 +229,38 @@ void test_parser(void)
 					->content.string->text, "file");
 	}
 
+	TEST_SECTION("parse_redirection　>");
+	{
+		t_parse_buffer	buf;
+		init_buf_with_string(&buf, "> file\n");
+		t_token	tok;
+
+		lex_get_token(&buf, &tok);
+
+		t_parse_ast *node = parse_redirection(&buf, &tok);
+		CHECK(node);
+		CHECK_EQ(node->type, ASTNODE_REDIRECTION);
+		CHECK_EQ(node->content.redirection->type, TOKTYPE_OUTPUT_REDIRECTION);
+		CHECK_EQ_STR(node->content.redirection->string_node
+					->content.string->text, "file");
+	}
+
+	TEST_SECTION("parse_redirection　>>");
+	{
+		t_parse_buffer	buf;
+		init_buf_with_string(&buf, ">> file\n");
+		t_token	tok;
+
+		lex_get_token(&buf, &tok);
+
+		t_parse_ast *node = parse_redirection(&buf, &tok);
+		CHECK(node);
+		CHECK_EQ(node->type, ASTNODE_REDIRECTION);
+		CHECK_EQ(node->content.redirection->type, TOKTYPE_OUTPUT_APPENDING);
+		CHECK_EQ_STR(node->content.redirection->string_node
+					->content.string->text, "file");
+	}
+
 	TEST_SECTION("parse_arguments 1 個");
 	{
 		t_parse_buffer	buf;

--- a/test/parse_test.c
+++ b/test/parse_test.c
@@ -133,64 +133,64 @@ void test_lexer()
 
 void check_string(t_parse_ast *node, const char *expected)
 {
-    CHECK_EQ(node->type, ASTNODE_STRING);
-    CHECK_EQ_STR(node->content.string->text, expected);
+	CHECK_EQ(node->type, ASTNODE_STRING);
+	CHECK_EQ_STR(node->content.string->text, expected);
 }
 
 void check_single_argument(t_parse_ast *node, const char *expected)
 {
-    t_parse_ast *str_node = node->content.arguments->string_node;
-    CHECK(str_node);
-    check_string(str_node, expected);
+	t_parse_ast *str_node = node->content.arguments->string_node;
+	CHECK(str_node);
+	check_string(str_node, expected);
 }
 
 void check_args(t_parse_ast	*node)
 {
-    CHECK(node);
-    CHECK_EQ(node->type, ASTNODE_ARGUMENTS);
+	CHECK(node);
+	CHECK_EQ(node->type, ASTNODE_ARGUMENTS);
 
-    check_single_argument(node, "file");
+	check_single_argument(node, "file");
 
-    node = node->content.arguments->rest_node;
-    t_parse_ast *red_node = node->content.arguments->redirection_node;
-    CHECK(red_node);
-    CHECK_EQ(red_node->type, ASTNODE_REDIRECTION);
-    CHECK_EQ(red_node->content.redirection->type, TOKTYPE_INPUT_REDIRECTION);
-    check_string(red_node->content.redirection->string_node, "abc");
+	node = node->content.arguments->rest_node;
+	t_parse_ast *red_node = node->content.arguments->redirection_node;
+	CHECK(red_node);
+	CHECK_EQ(red_node->type, ASTNODE_REDIRECTION);
+	CHECK_EQ(red_node->content.redirection->type, TOKTYPE_INPUT_REDIRECTION);
+	check_string(red_node->content.redirection->string_node, "abc");
 }
 
 void check_piped_commands(t_parse_ast *node)
 {
-    CHECK_EQ(node->type, ASTNODE_PIPED_COMMANDS);
-    CHECK(node->content.piped_commands->command_node);
-    CHECK(node->content.piped_commands->next);
-    t_parse_ast *next = node->content.piped_commands->next;
-    CHECK_EQ(next->type, ASTNODE_PIPED_COMMANDS);
-    CHECK(next->content.piped_commands->command_node);
-    check_args(next->content.piped_commands->command_node
-              ->content.command->arguments_node);
-    CHECK(!next->content.piped_commands->next);
+	CHECK_EQ(node->type, ASTNODE_PIPED_COMMANDS);
+	CHECK(node->content.piped_commands->command_node);
+	CHECK(node->content.piped_commands->next);
+	t_parse_ast *next = node->content.piped_commands->next;
+	CHECK_EQ(next->type, ASTNODE_PIPED_COMMANDS);
+	CHECK(next->content.piped_commands->command_node);
+	check_args(next->content.piped_commands->command_node
+			  ->content.command->arguments_node);
+	CHECK(!next->content.piped_commands->next);
 }
 
 void check_delimiter(t_parse_ast *node)
 {
-    CHECK_EQ(node->type, ASTNODE_DELIMITER);
-    CHECK_EQ(node->content.delimiter->type, TOKTYPE_SEMICOLON);
+	CHECK_EQ(node->type, ASTNODE_DELIMITER);
+	CHECK_EQ(node->content.delimiter->type, TOKTYPE_SEMICOLON);
 }
 
 void check_piped_seqence(t_parse_ast *node)
 {
-    check_piped_commands(node->content.sequential_commands->pipcmd_node);
-    check_delimiter(
-        node->content.sequential_commands
-        ->delimiter_node);
-    check_single_argument(
-        node->content.sequential_commands
-        ->rest_node->content.sequential_commands
-        ->pipcmd_node->content.piped_commands
-        ->command_node->content.command
-        ->arguments_node,
-        "xyz");
+	check_piped_commands(node->content.sequential_commands->pipcmd_node);
+	check_delimiter(
+		node->content.sequential_commands
+		->delimiter_node);
+	check_single_argument(
+		node->content.sequential_commands
+		->rest_node->content.sequential_commands
+		->pipcmd_node->content.piped_commands
+		->command_node->content.command
+		->arguments_node,
+		"xyz");
 }
 
 void test_parser(void)
@@ -213,7 +213,7 @@ void test_parser(void)
 		CHECK_EQ(node->content.string->next, NULL);
 	}
 
-	TEST_SECTION("parse_redirection");
+	TEST_SECTION("parse_redirection　<");
 	{
 		t_parse_buffer	buf;
 		init_buf_with_string(&buf, "< file\n");
@@ -317,10 +317,10 @@ void test_parser(void)
 		lex_get_token(&buf, &tok);
 
 		t_parse_ast *node = parse_arguments(&buf, &tok);
-        check_args(node);
+		check_args(node);
 	}
 
-    TEST_SECTION("parse_command ファイル + リダイレクト");
+	TEST_SECTION("parse_command ファイル + リダイレクト");
 	{
 		t_parse_buffer	buf;
 		init_buf_with_string(&buf, "file < abc \n");
@@ -329,11 +329,11 @@ void test_parser(void)
 		lex_get_token(&buf, &tok);
 
 		t_parse_ast *node = parse_command(&buf, &tok);
-        CHECK_EQ(node->type, ASTNODE_COMMAND);
-        check_args(node->content.command->arguments_node);
+		CHECK_EQ(node->type, ASTNODE_COMMAND);
+		check_args(node->content.command->arguments_node);
 	}
 
-    TEST_SECTION("parse_piped_commands パイプなし");
+	TEST_SECTION("parse_piped_commands パイプなし");
 	{
 		t_parse_buffer	buf;
 		init_buf_with_string(&buf, "abc \n");
@@ -342,7 +342,7 @@ void test_parser(void)
 		lex_get_token(&buf, &tok);
 
 		t_parse_ast *node = parse_piped_commands(&buf, &tok);
-        CHECK_EQ(node->type, ASTNODE_PIPED_COMMANDS);
+		CHECK_EQ(node->type, ASTNODE_PIPED_COMMANDS);
 
 		t_parse_ast *cmd = node->content.piped_commands->command_node;
 		CHECK(cmd);
@@ -354,7 +354,7 @@ void test_parser(void)
 		CHECK(!node->content.piped_commands->next);
 	}
 
-    TEST_SECTION("parse_piped_commands パイプあり");
+	TEST_SECTION("parse_piped_commands パイプあり");
 	{
 		t_parse_buffer	buf;
 		init_buf_with_string(&buf, "abc | file < abc \n");
@@ -363,10 +363,10 @@ void test_parser(void)
 		lex_get_token(&buf, &tok);
 
 		t_parse_ast *node = parse_piped_commands(&buf, &tok);
-        check_piped_commands(node);
+		check_piped_commands(node);
 	}
 
-    TEST_SECTION("parse_delimiter");
+	TEST_SECTION("parse_delimiter");
 	{
 		t_parse_buffer	buf;
 		init_buf_with_string(&buf, "; \n");
@@ -374,37 +374,37 @@ void test_parser(void)
 
 		lex_get_token(&buf, &tok);
 		t_parse_ast *node = parse_delimiter(&buf, &tok);
-        check_delimiter(node);
+		check_delimiter(node);
 	}
 
-    TEST_SECTION("parse_sequential_commands 単純なケース");
-    {
+	TEST_SECTION("parse_sequential_commands 単純なケース");
+	{
 		t_parse_buffer	buf;
 		init_buf_with_string(&buf, " abc ; xyz \n");
 		t_token	tok;
 
 		lex_get_token(&buf, &tok);
 		t_parse_ast *node = parse_sequential_commands(&buf, &tok);
-        check_single_argument(
-            node->content.sequential_commands
-            ->pipcmd_node->content.piped_commands
-            ->command_node->content.command
-            ->arguments_node,
-            "abc");
-        check_delimiter(
-            node->content.sequential_commands
-            ->delimiter_node);
-        check_single_argument(
-            node->content.sequential_commands
-            ->rest_node->content.sequential_commands
-            ->pipcmd_node->content.piped_commands
-            ->command_node->content.command
-            ->arguments_node,
-            "xyz");
-    }
+		check_single_argument(
+			node->content.sequential_commands
+			->pipcmd_node->content.piped_commands
+			->command_node->content.command
+			->arguments_node,
+			"abc");
+		check_delimiter(
+			node->content.sequential_commands
+			->delimiter_node);
+		check_single_argument(
+			node->content.sequential_commands
+			->rest_node->content.sequential_commands
+			->pipcmd_node->content.piped_commands
+			->command_node->content.command
+			->arguments_node,
+			"xyz");
+	}
 
-    TEST_SECTION("parse_sequential_commands パイプあり");
-    {
+	TEST_SECTION("parse_sequential_commands パイプあり");
+	{
 		t_parse_buffer	buf;
 		init_buf_with_string(&buf, " abc | file < abc ; xyz \n");
 		t_token	tok;
@@ -412,8 +412,8 @@ void test_parser(void)
 		lex_get_token(&buf, &tok);
 		t_parse_ast *node = parse_sequential_commands(&buf, &tok);
 
-        check_piped_seqence(node);
-    }
+		check_piped_seqence(node);
+	}
 
 	TEST_SECTION("parse_command_line パイプなし");
 	{
@@ -432,8 +432,8 @@ void test_parser(void)
 			"abc");
 	}
 
-    TEST_SECTION("parse_command_line");
-    {
+	TEST_SECTION("parse_command_line");
+	{
 		t_parse_buffer	buf;
 		init_buf_with_string(&buf, " abc | file < abc ; xyz \n");
 		t_token	tok;
@@ -441,15 +441,15 @@ void test_parser(void)
 		lex_get_token(&buf, &tok);
 		t_parse_ast *node = parse_command_line(&buf, &tok);
 
-        check_piped_seqence(node->content.command_line->seqcmd_node);
-        CHECK_EQ(node->content.command_line->delimiter_node, NULL);
-    }
+		check_piped_seqence(node->content.command_line->seqcmd_node);
+		CHECK_EQ(node->content.command_line->delimiter_node, NULL);
+	}
 }
 
 int main()
 {
-    test_lexer();
-    test_parser();
+	test_lexer();
+	test_parser();
 	int fail_count = print_result();
 	return (fail_count);
 }


### PR DESCRIPTION
closes #30 

コマンド実行のときにないと困りそうなので作りました。
あと、これとは直接関係ないんですが、テストコードのインデントにスペースとタブがまざっていたので、タブに統一しました。
このせいで diff が見にくくなってしまい申し訳ないです。

URL の末尾に w=1 というパラメタを追加すると、スペースの差異を無視した diff が表示されます。