### PR TITLE
AST のリストを作って一括して解放できるようにした。

### DIFF
--- a/parse.h
+++ b/parse.h
@@ -30,7 +30,7 @@ typedef struct s_parse_ast	t_parse_ast;
 
 typedef struct s_parse_node_string
 {
-	const char		*text;
+	char			*text;
 	t_token_type	type;
 	t_parse_ast		*next;
 }	t_parse_node_string;
@@ -107,5 +107,13 @@ t_parse_ast	*parse_command_line(t_parse_buffer *buf, t_token *tok);
 
 void		parse_fatal_error(void);
 void		parse_skip_spaces(t_parse_buffer *buf, t_token *tok);
+
+typedef struct s_parse_ast_list
+{
+	t_parse_ast				ast;
+	struct s_parse_ast_list	*next;
+}	t_parse_ast_list;
+
+void		parse_free_all_ast(void);
 
 #endif

--- a/parse_utils.c
+++ b/parse_utils.c
@@ -11,20 +11,6 @@ void	parse_skip_spaces(t_parse_buffer *buf, t_token *tok)
 	}
 }
 
-t_parse_ast	*parse_new_ast_node(t_parse_ast_type type, void *content)
-{
-	t_parse_ast	*dest;
-
-	if (!(type > ASTNODE_NONE && type < ASTNODE_INVALID))
-		parse_fatal_error();
-	dest = malloc(sizeof(t_parse_ast));
-	if (!dest || !content)
-		parse_fatal_error();
-	dest->type = type;
-	dest->content.void_ptr = content;
-	return (dest);
-}
-
 /*
  * TODO: replace with proper error handling
  */

--- a/parse_utils2.c
+++ b/parse_utils2.c
@@ -1,0 +1,53 @@
+#include <stdlib.h>
+#include "parse.h"
+
+static t_parse_ast_list	**get_ast_list(void)
+{
+	static t_parse_ast_list	*list;
+
+	return (&list);
+}
+
+static t_parse_ast_list	*create_ast_on_list(void)
+{
+	t_parse_ast_list	*list;
+
+	list = malloc(sizeof(t_parse_ast_list));
+	if (!list)
+		parse_fatal_error();
+	list->next = *get_ast_list();
+	*get_ast_list() = list;
+	return (list);
+}
+
+void	parse_free_all_ast(void)
+{
+	t_parse_ast_list	*list;
+	t_parse_ast_list	*next;
+
+	list = *get_ast_list();
+	while (list)
+	{
+		next = list->next;
+		if (list->ast.type == ASTNODE_STRING)
+			free(list->ast.content.string->text);
+		free(list->ast.content.void_ptr);
+		free(list);
+		list = next;
+	}
+	*get_ast_list() = NULL;
+}
+
+t_parse_ast	*parse_new_ast_node(t_parse_ast_type type, void *content)
+{
+	t_parse_ast_list	*list;
+
+	if (!(type > ASTNODE_NONE && type < ASTNODE_INVALID))
+		parse_fatal_error();
+	if (!content)
+		parse_fatal_error();
+	list = create_ast_on_list();
+	list->ast.type = type;
+	list->ast.content.void_ptr = content;
+	return (&list->ast);
+}

--- a/test/Makefile
+++ b/test/Makefile
@@ -7,6 +7,7 @@ SRCS = ../env.c \
 	   ../parse1.c \
 	   ../parse2.c \
 	   ../parse_utils.c \
+	   ../parse_utils2.c \
 	   ../exec.c \
 	   ../path.c \
 	   ../cmd_exec_command.c \
@@ -20,7 +21,7 @@ TEST_UTILS = test.c \
 			 test.h
 
 run: parse_test env_test path_test exec_test command_exec_test
-	./parse_test
+	valgrind -q --leak-check=full --errors-for-leak-kinds=all --show-leak-kinds=all --error-exitcode=99 ./parse_test
 	./env_test
 	./path_test
 	./exec_test

--- a/test/Makefile
+++ b/test/Makefile
@@ -21,7 +21,8 @@ TEST_UTILS = test.c \
 			 test.h
 
 run: parse_test env_test path_test exec_test command_exec_test
-	valgrind -q --leak-check=full --errors-for-leak-kinds=all --show-leak-kinds=all --error-exitcode=99 ./parse_test
+#	valgrind -q --leak-check=full --errors-for-leak-kinds=all --show-leak-kinds=all --error-exitcode=99 ./parse_test
+	./parse_test
 	./env_test
 	./path_test
 	./exec_test

--- a/test/parse_test.c
+++ b/test/parse_test.c
@@ -541,6 +541,7 @@ int main()
 {
 	test_lexer();
 	test_parser();
+	parse_free_all_ast();
 	int fail_count = print_result();
 	return (fail_count);
 }


### PR DESCRIPTION
closes #29 

AST を作成するときに内部でリストを作って、最後にまとめて解放するようにしました。

テストコードの最後などに以下のコードを足してください：
```
parse_free_all_ast();
```
