### PR TITLE
command_invocation に関するメモリリークのエラーを修正

### DIFF
--- a/cmd_cmd_invocation.c
+++ b/cmd_cmd_invocation.c
@@ -52,7 +52,7 @@ void	cmd_free_cmdinvo(t_command_invocation *cmds)
 	else
 	{
 		current_cmd = cmds;
-		while (current_cmd->piped_command)
+		while (current_cmd)
 		{
 			free((void *)current_cmd->input_file_path);
 			free((void *)current_cmd->output_file_path);

--- a/cmd_exec_commands.c
+++ b/cmd_exec_commands.c
@@ -16,8 +16,6 @@ static int	cmd_connect_pipe(
  * fork and execute commands.
  *
  * return: status of last command
- * 
- * FIXME: エラーが発生した時にpid_lstがメモリリークを起こす
  */
 int	cmd_exec_commands(t_command_invocation *command)
 {

--- a/cmd_pid.c
+++ b/cmd_pid.c
@@ -29,12 +29,14 @@ t_list	*cmd_lstadd_back_pid(t_list **lst, int pid)
  */
 int	cmd_wait_pid_lst(t_list *lst)
 {
-	int	status;
+	int		status;
+	t_list	*current_lst;
 
-	while (lst)
+	current_lst = lst;
+	while (current_lst)
 	{
-		waitpid(*((int *)lst->content), &status, 0);
-		lst = lst->next;
+		waitpid(*((int *)current_lst->content), &status, 0);
+		current_lst = current_lst->next;
 	}
 	ft_lstclear(&lst, free);
 	return (status);

--- a/convert_ast2cmdinvo.c
+++ b/convert_ast2cmdinvo.c
@@ -43,7 +43,9 @@ int	cmd_process_redirection_node(t_parse_node_redirection *redirection_node,
 	const char	*text;
 
 	redirection_type = redirection_node->type;
-	text = redirection_node->string_node->content.string->text;
+	text = ft_strdup(redirection_node->string_node->content.string->text);
+	if (!text)
+		return (ERROR);
 	if (redirection_type == TOKTYPE_INPUT_REDIRECTION)
 		command->input_file_path = text;
 	else if (redirection_type == TOKTYPE_OUTPUT_REDIRECTION)

--- a/convert_ast2cmdinvo.c
+++ b/convert_ast2cmdinvo.c
@@ -14,9 +14,13 @@ int	cmd_process_string_node(t_parse_node_string *string_node,
 	t_command_invocation *command)
 {
 	const char	**strarr;
+	const char	*text;
 
+	text = ft_strdup(string_node->text);
+	if (!text)
+		return (ERROR);
 	strarr = (const char **)ptrarr_add_ptr((void **)command->exec_and_args,
-			(void *)string_node->text);
+			(void *)text);
 	if (!strarr)
 		return (ERROR);
 	free((void **)command->exec_and_args);

--- a/exec.c
+++ b/exec.c
@@ -27,14 +27,14 @@ char	*find_executable_file_in_dir(char *filename, char *dirpath)
 		{
 			fullpath = path_join(dirpath, dirp->d_name);
 			if (!fullpath)
-				return (NULL);
+				return (free_and_rtn_ptr(dir, NULL));
 			if (stat(fullpath, &buf) == 0 && S_ISREG(buf.st_mode))
-				return (fullpath);
+				return (free_and_rtn_ptr(dir, fullpath));
 			free(fullpath);
 		}
 		dirp = readdir(dir);
 	}
-	return (NULL);
+	return (free_and_rtn_ptr(dir, NULL));
 }
 
 /*

--- a/libft/free_utils.c
+++ b/libft/free_utils.c
@@ -5,3 +5,9 @@ void	free_and_assign_null(void **p)
 	free(*p);
 	*p = NULL;
 }
+
+void*	free_and_rtn_ptr(void *p, void *val)
+{
+	free(p);
+	return (val);
+}

--- a/libft/free_utils.c
+++ b/libft/free_utils.c
@@ -6,7 +6,7 @@ void	free_and_assign_null(void **p)
 	*p = NULL;
 }
 
-void*	free_and_rtn_ptr(void *p, void *val)
+void	*free_and_rtn_ptr(void *p, void *val)
 {
 	free(p);
 	return (val);

--- a/libft/libft.h
+++ b/libft/libft.h
@@ -66,7 +66,7 @@ void				put_err_msg(char *str);
 int					put_err_msg_and_ret(char *str);
 void				put_err_msg_and_exit(char *str);
 void				free_and_assign_null(void **p);
-void*				free_and_rtn_ptr(void *p, void *val);
+void				*free_and_rtn_ptr(void *p, void *val);
 size_t				ptrarr_len(void **ptrarr);
 void				free_ptrarr(void **ptrarr);
 void				*free_ptrarr_and_rtn_null(void **ptrarr);

--- a/libft/libft.h
+++ b/libft/libft.h
@@ -66,6 +66,7 @@ void				put_err_msg(char *str);
 int					put_err_msg_and_ret(char *str);
 void				put_err_msg_and_exit(char *str);
 void				free_and_assign_null(void **p);
+void*				free_and_rtn_ptr(void *p, void *val);
 size_t				ptrarr_len(void **ptrarr);
 void				free_ptrarr(void **ptrarr);
 void				*free_ptrarr_and_rtn_null(void **ptrarr);

--- a/test/Makefile
+++ b/test/Makefile
@@ -28,7 +28,7 @@ VALGRIND = valgrind -q --leak-check=full --errors-for-leak-kinds=all --show-leak
 run: parse_test env_test path_test exec_test command_exec_test ast2cmdinvo_test
 	${VALGRIND} ./parse_test
 	${VALGRIND} ./env_test
-	./path_test
+	${VALGRIND} ./path_test
 	./exec_test
 	./command_exec_test
 	${VALGRIND} ./ast2cmdinvo_test

--- a/test/Makefile
+++ b/test/Makefile
@@ -30,7 +30,7 @@ run: parse_test env_test path_test exec_test command_exec_test ast2cmdinvo_test
 	${VALGRIND} ./env_test
 	${VALGRIND} ./path_test
 	${VALGRIND} ./exec_test
-	./command_exec_test
+	${VALGRIND} ./command_exec_test
 	${VALGRIND} ./ast2cmdinvo_test
 
 SRCS_PARSE = $(wildcard ../lexer*.c ../parse*.c) ../libft/ft_memcpy.c

--- a/test/Makefile
+++ b/test/Makefile
@@ -29,7 +29,7 @@ run: parse_test env_test path_test exec_test command_exec_test ast2cmdinvo_test
 	./path_test
 	./exec_test
 	./command_exec_test
-	./ast2cmdinvo_test
+	valgrind -q --leak-check=full --errors-for-leak-kinds=all --show-leak-kinds=all --error-exitcode=99 ./ast2cmdinvo_test
 
 SRCS_PARSE = $(wildcard ../lexer*.c ../parse*.c) ../libft/ft_memcpy.c
 

--- a/test/Makefile
+++ b/test/Makefile
@@ -27,7 +27,7 @@ VALGRIND = valgrind -q --leak-check=full --errors-for-leak-kinds=all --show-leak
 
 run: parse_test env_test path_test exec_test command_exec_test ast2cmdinvo_test
 	${VALGRIND} ./parse_test
-	./env_test
+	${VALGRIND} ./env_test
 	./path_test
 	./exec_test
 	./command_exec_test

--- a/test/Makefile
+++ b/test/Makefile
@@ -23,13 +23,15 @@ HEADERS = ../env.h \
 TEST_UTILS = test.c \
 			 test.h
 
+VALGRIND = valgrind -q --leak-check=full --errors-for-leak-kinds=all --show-leak-kinds=all --error-exitcode=99
+
 run: parse_test env_test path_test exec_test command_exec_test ast2cmdinvo_test
-	valgrind -q --leak-check=full --errors-for-leak-kinds=all --show-leak-kinds=all --error-exitcode=99 ./parse_test
+	${VALGRIND} ./parse_test
 	./env_test
 	./path_test
 	./exec_test
 	./command_exec_test
-	valgrind -q --leak-check=full --errors-for-leak-kinds=all --show-leak-kinds=all --error-exitcode=99 ./ast2cmdinvo_test
+	${VALGRIND} ./ast2cmdinvo_test
 
 SRCS_PARSE = $(wildcard ../lexer*.c ../parse*.c) ../libft/ft_memcpy.c
 

--- a/test/Makefile
+++ b/test/Makefile
@@ -29,7 +29,7 @@ run: parse_test env_test path_test exec_test command_exec_test ast2cmdinvo_test
 	${VALGRIND} ./parse_test
 	${VALGRIND} ./env_test
 	${VALGRIND} ./path_test
-	./exec_test
+	${VALGRIND} ./exec_test
 	./command_exec_test
 	${VALGRIND} ./ast2cmdinvo_test
 

--- a/test/ast2cmdinvo_test.c
+++ b/test/ast2cmdinvo_test.c
@@ -249,6 +249,7 @@ int main()
 		cmd_free_cmdinvo(expected_first);
 	}
 
+	parse_free_all_ast();
 	int fail_count = print_result();
 	return (fail_count);
 }

--- a/test/ast2cmdinvo_test.c
+++ b/test/ast2cmdinvo_test.c
@@ -105,7 +105,7 @@ int main()
 
 		/* テスト */
 		t_command_invocation *actual = cmd_ast_cmd2cmdinvo(node->content.command);
-		t_command_invocation *expected = cmd_init_cmdinvo(NULL, "abc", (const char **)ft_split("file", ' '), 0);
+		t_command_invocation *expected = cmd_init_cmdinvo(NULL, ft_strdup("abc"), (const char **)ft_split("file", ' '), 0);
 		CHECK(actual);
 		check_cmdinvo(actual, expected);
 
@@ -127,7 +127,7 @@ int main()
 
 		/* テスト */
 		t_command_invocation *actual = cmd_ast_cmd2cmdinvo(node->content.command);
-		t_command_invocation *expected = cmd_init_cmdinvo("abc", NULL, (const char **)ft_split("file", ' '), CMD_REDIRECT_WRITE);
+		t_command_invocation *expected = cmd_init_cmdinvo(ft_strdup("abc"), NULL, (const char **)ft_split("file", ' '), CMD_REDIRECT_WRITE);
 		CHECK(actual);
 		check_cmdinvo(actual, expected);
 
@@ -149,7 +149,7 @@ int main()
 
 		/* テスト */
 		t_command_invocation *actual = cmd_ast_cmd2cmdinvo(node->content.command);
-		t_command_invocation *expected = cmd_init_cmdinvo("abc", NULL, (const char **)ft_split("file", ' '), CMD_REDIRECT_APPEND);
+		t_command_invocation *expected = cmd_init_cmdinvo(ft_strdup("abc"), NULL, (const char **)ft_split("file", ' '), CMD_REDIRECT_APPEND);
 		CHECK(actual);
 		check_cmdinvo(actual, expected);
 
@@ -215,7 +215,7 @@ int main()
 		/* テスト */
 		t_command_invocation *actual = cmd_ast_pipcmds2cmdinvo(node->content.piped_commands);
 		t_command_invocation *expected_first = cmd_init_cmdinvo(NULL, NULL, (const char **)ft_split("abc", ' '), 0);
-		t_command_invocation *expected_second = cmd_init_cmdinvo(NULL, "abc", (const char **)ft_split("file", ' '), 0);
+		t_command_invocation *expected_second = cmd_init_cmdinvo(NULL, ft_strdup("abc"), (const char **)ft_split("file", ' '), 0);
 		expected_first->piped_command = expected_second;
 
 		CHECK(actual);
@@ -239,7 +239,7 @@ int main()
 		/* テスト */
 		t_command_invocation *actual = cmd_ast_pipcmds2cmdinvo(node->content.piped_commands);
 		t_command_invocation *expected_first = cmd_init_cmdinvo(NULL, NULL, (const char **)ft_split("abc", ' '), 0);
-		t_command_invocation *expected_second = cmd_init_cmdinvo("abc", NULL, (const char **)ft_split("file", ' '), 0);
+		t_command_invocation *expected_second = cmd_init_cmdinvo(ft_strdup("abc"), NULL, (const char **)ft_split("file", ' '), 0);
 		expected_first->piped_command = expected_second;
 
 		CHECK(actual);

--- a/test/command_exec_test.c
+++ b/test/command_exec_test.c
@@ -148,6 +148,7 @@ int main(){
 		int status = cmd_exec_commands(&cat_command);
 		CHECK_EQ(status, 0);
 		CHECK(system("cat /etc/passwd | wc | cat > expected.txt ; diff --color -u expected.txt output.txt") == 0);
+		free_ptrarr((void**)lastcat_command.exec_and_args);
 		free_ptrarr((void**)cat_command.exec_and_args);
 		free_ptrarr((void**)wc_command.exec_and_args);
 		remove("output.txt");
@@ -176,6 +177,7 @@ int main(){
 		int status = cmd_exec_commands(&cat_command);
 		CHECK_EQ(status, 0);
 		CHECK(system("cat /etc/passwd > /dev/null | wc | cat > expected.txt ; diff --color -u expected.txt output.txt") == 0);
+		free_ptrarr((void**)lastcat_command.exec_and_args);
 		free_ptrarr((void**)cat_command.exec_and_args);
 		free_ptrarr((void**)wc_command.exec_and_args);
 		remove("output.txt");

--- a/test/command_exec_test.c
+++ b/test/command_exec_test.c
@@ -204,6 +204,7 @@ int main(){
 		int status = cmd_exec_commands(&cat_command);
 		CHECK_EQ(status, 0);
 		CHECK(system("cat test.h | wc < test.c | cat > expected.txt ; diff --color -u expected.txt output.txt") == 0);
+		free_ptrarr((void**)lastcat_command.exec_and_args);
 		free_ptrarr((void**)cat_command.exec_and_args);
 		free_ptrarr((void**)wc_command.exec_and_args);
 		remove("output.txt");

--- a/test/env_test.c
+++ b/test/env_test.c
@@ -11,6 +11,8 @@ int main(){
 		CHECK_EQ_STR(str_arr[0], "PATH");
 		CHECK_EQ_STR(str_arr[1], "/bin/:/usr/bin/:/home/jun/bin");
 		CHECK_EQ(str_arr[2], NULL);
+
+		free_ptrarr((void **)str_arr);
 	}
 
 	TEST_SECTION("split_first_c() 区切り文字が入っていない");
@@ -20,6 +22,8 @@ int main(){
 		CHECK_EQ_STR(str_arr[0], "PATH/bin/:/usr/bin/:/home/jun/bin");
 		CHECK_EQ(str_arr[1], NULL);
 		CHECK_EQ(str_arr[2], NULL);
+
+		free_ptrarr((void **)str_arr);
 	}
 
 	TEST_SECTION("get_env() 通常ケース");
@@ -51,6 +55,8 @@ int main(){
 		char *kvstr = "PATH=/bin/:/usr/bin/:/home/jun/bin";
 		char *val_str = get_val_from_kvstr(kvstr, '=');
 		CHECK_EQ_STR(val_str, "/bin/:/usr/bin/:/home/jun/bin");
+
+		free(val_str);
 	}
 
 	TEST_SECTION("get_val_from_kvstr() 区切り文字が無い");
@@ -58,6 +64,8 @@ int main(){
 		char *kvstr = "PATH/bin/:/usr/bin/:/home/jun/bin";
 		char *val_str = get_val_from_kvstr(kvstr, '=');
 		CHECK_EQ(val_str, NULL);
+
+		free(val_str);
 	}
 
 	TEST_SECTION("get_val_from_kvstr() 区切り文字が連続で並ぶ");
@@ -65,6 +73,8 @@ int main(){
 		char *kvstr = "PATH===/bin/:/usr/bin/:/home/jun/bin";
 		char *val_str = get_val_from_kvstr(kvstr, '=');
 		CHECK_EQ_STR(val_str, "==/bin/:/usr/bin/:/home/jun/bin");
+
+		free(val_str);
 	}
 
 	TEST_SECTION("get_env_val() 通常ケース");
@@ -74,12 +84,16 @@ int main(){
 		char *val_str = get_env_val("GET_ENV_TEST");
 		CHECK_EQ_STR(val_str, "/bin/:/usr/bin/:/home/jun/bin");
 		environ[0] = original0;
+
+		free(val_str);
 	}
 
 	TEST_SECTION("get_env_val() 指定された環境変数が存在しない");
 	{
 		char *val_str = get_env_val("THIS_IS_NOT_EXIST_IN_ENVIRON");
 		CHECK_EQ(val_str, NULL);
+
+		free(val_str);
 	}
 
 	int fail_count = print_result();


### PR DESCRIPTION
#54 からチェックアウトしているので, #54 を先にレビューして頂きたいです.

## 概要

`command_invotion` に関するテストを実行した時に発生していたメモリリークを修正しました

## 注意点

`test/command_exec_test` の中にわざと存在しないコマンドを渡して `execvp()` を失敗させるというテストケースがあるのですが,  valgrind がどうやら `execve()` が失敗するとエラーメッセージを出すっぽくて, 途中でvalgrindからのメッセージが表示されます. ただ, 終了ステータスは正常なので問題は無いものと判断しました.

このメッセージについて何か知っていればおしえて頂きたいです.