### PR TITLE
コマンドラインからの入力を実際に実行する

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,10 @@ LIBFT_MAKE = $(MAKE) -C $(LIBFT_PATH)
 LIBFT_LIB = ./libft/libft.a
 
 HEADER_FILES = minishell.h
-SRCS = $(wildcard *.c)
+SRCS = cmd_cmd_invocation.c cmd_cmd_invocation2.c cmd_exec_command.c	\
+	cmd_exec_commands.c cmd_pid.c cmd_pipe.c convert_ast2cmdinvo.c		\
+	env.c exec.c lexer1.c lexer2.c minishell.c parse1.c parse2.c		\
+	parse_utils.c parse_utils2.c path.c
 OBJS = $(SRCS:.c=.o)
 
 all: $(NAME)

--- a/cmd_exec_command.c
+++ b/cmd_exec_command.c
@@ -63,7 +63,8 @@ int	cmd_set_output_file(t_command_invocation *command)
 }
 
 /*
- * execute one command.
+ * Execute a command.
+ * This function is supposed to be called in child process.
  *
  * command: command
  * pipe_prev_fd[2]: A pipe that connects the previous and current process.
@@ -79,7 +80,7 @@ void	cmd_exec_command(t_command_invocation *command,
 			put_err_msg_and_exit("error child dup2()");
 		close(pipe_prev_fd[0]);
 	}
-	if (pipe_fd)
+	if (command->piped_command)
 	{
 		close(pipe_fd[0]);
 		if (dup2(pipe_fd[1], STDOUT_FILENO) == -1)

--- a/cmd_exec_commands.c
+++ b/cmd_exec_commands.c
@@ -28,8 +28,6 @@ int	cmd_exec_commands(t_command_invocation *command)
 	pid_lst = NULL;
 	while (command)
 	{
-		if (!command->piped_command)
-			pipe_fd[1] = STDOUT_FILENO;
 		if (pipe(pipe_fd) == -1)
 			return (put_err_msg_and_ret("error pipe()"));
 		pid = fork();

--- a/minishell.c
+++ b/minishell.c
@@ -2,17 +2,45 @@
 #include "minishell.h"
 #include "parse.h"
 
+void	die()
+{
+	int	*nullpo;
+
+	nullpo = NULL;
+	nullpo[0xdead] = 1;
+}
+
 void	init_buffer(t_parse_buffer *buf)
 {
 	buf->cur_pos = 0;
 	buf->size = 0;
 }
 
+void	invoke_sequential_commands(t_parse_ast *seqcmd)
+{
+	int						status;
+	t_command_invocation	*inv;
+
+	while (seqcmd && seqcmd->content.sequential_commands->pipcmd_node)
+	{
+		if(seqcmd->type != ASTNODE_SEQ_COMMANDS)
+			die();
+		inv = cmd_ast_pipcmds2cmdinvo(
+			seqcmd->content.sequential_commands->pipcmd_node
+			->content.piped_commands);
+		if(!inv)
+			die();
+		status = cmd_exec_commands(inv);
+		seqcmd = seqcmd->content.sequential_commands->rest_node;
+	}
+}
+
 int	main(int argc, char **argv)
 {
-	t_parse_ast		*cmdline;
-	t_parse_buffer	buf;
-	t_token			tok;
+	t_parse_ast				*cmdline;
+	t_parse_buffer			buf;
+	t_token					tok;
+	t_parse_ast				*seqcmd;
 
 	init_buffer(&buf);
 	printf("Welcome Minishell\n");
@@ -23,7 +51,10 @@ int	main(int argc, char **argv)
 		lex_get_token(&buf, &tok);
 		cmdline = parse_command_line(&buf, &tok);
 		if (cmdline)
-			printf("TODO: process the command line... %p\n", cmdline);
+		{
+			seqcmd = cmdline->content.command_line->seqcmd_node;
+			invoke_sequential_commands(seqcmd);
+		}
 		else
 			put_err_msg("Parse error.");
 	}

--- a/minishell.c
+++ b/minishell.c
@@ -2,7 +2,7 @@
 #include "minishell.h"
 #include "parse.h"
 
-void	die()
+void	die(void)
 {
 	int	*nullpo;
 
@@ -23,12 +23,12 @@ void	invoke_sequential_commands(t_parse_ast *seqcmd)
 
 	while (seqcmd && seqcmd->content.sequential_commands->pipcmd_node)
 	{
-		if(seqcmd->type != ASTNODE_SEQ_COMMANDS)
+		if (seqcmd->type != ASTNODE_SEQ_COMMANDS)
 			die();
 		inv = cmd_ast_pipcmds2cmdinvo(
-			seqcmd->content.sequential_commands->pipcmd_node
-			->content.piped_commands);
-		if(!inv)
+				seqcmd->content.sequential_commands->pipcmd_node
+				->content.piped_commands);
+		if (!inv)
 			die();
 		status = cmd_exec_commands(inv);
 		seqcmd = seqcmd->content.sequential_commands->rest_node;


### PR DESCRIPTION
メモリの解放などをしていませんが、一応シェルとして動くようになりました。
ただ、なぜかコマンドからの標準出力の内容がエコーされません。

現状では下のようなシェルのセッションができます。

```
$ ./minishell 
Welcome Minishell
minish > ls > x.txt ; cat x.txt
minish > cat y.txt
cat: y.txt: そのようなファイルやディレクトリはありません
minish > date
minish > ^C
```

実際にコマンドは実行できているようで、上のコマンドで作成した `x.txt` はちゃんとありました。また、エラーは出力されるようです。