### PR TITLE
リダイレクションの環境変数対応

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,14 +9,15 @@ HEADER_FILES = minishell.h
 SRCS = cmd_cmd_invocation.c cmd_cmd_invocation2.c cmd_exec_command.c	\
 	cmd_exec_commands.c cmd_pid.c cmd_pipe.c convert_ast2cmdinvo.c		\
 	env.c exec.c lexer1.c lexer2.c minishell.c parse1.c parse2.c		\
-	parse_utils.c parse_utils2.c path.c
+	parse_utils.c parse_utils2.c path.c \
+	string_node2string.c expand_env_var.c expand_string_node.c split_expanded_str.c
 OBJS = $(SRCS:.c=.o)
 
 all: $(NAME)
 
 $(NAME): ${HEADER_FILES} ${OBJS}
 	$(LIBFT_MAKE)
-	$(CC) -g -fsanitize=address -o $(NAME) $(SRCS) $(LIBFT_LIB) -lbsd
+	$(CC) -g -fsanitize=address -o $(NAME) $(OBJS) $(LIBFT_LIB) -lbsd
 
 clean:
 	$(LIBFT_MAKE) clean

--- a/cmd_exec_command.c
+++ b/cmd_exec_command.c
@@ -93,7 +93,7 @@ int	cmd_set_output_file(t_command_invocation *command)
 			flag_open |= O_APPEND;
 		else
 			flag_open |= O_TRUNC;
-		fd = open(red->filepath, O_WRONLY | O_CREAT | flag_open,
+		fd = open(filepath, O_WRONLY | O_CREAT | flag_open,
 				S_IRUSR | S_IWUSR | S_IRGRP | S_IWGRP | S_IROTH);
 		if (fd == -1)
 			return (put_err_msg_and_ret("error open()"));

--- a/cmd_exec_command.c
+++ b/cmd_exec_command.c
@@ -11,7 +11,7 @@
  * return: 環境変数展開などが完了した文字列.
  *   展開した結果文字列が2つ以上の場合はエラーなのでNULLを返す.
  */
-char *expand_redirect_filepath(char *red_target)
+char	*expand_redirect_filepath(char *red_target)
 {
 	char	*expanded_str;
 	char	**splitted_expanded_str;
@@ -21,7 +21,8 @@ char *expand_redirect_filepath(char *red_target)
 	expanded_str = expand_env_var(red_target);
 	splitted_expanded_str = split_expanded_str(expanded_str);
 	free(expanded_str);
-	if (!splitted_expanded_str || ptrarr_len((void **)splitted_expanded_str) != 1)
+	if (!splitted_expanded_str
+		|| ptrarr_len((void **)splitted_expanded_str) != 1)
 	{
 		errmsg = ft_strjoin(red_target, ": ambiguous redirect\n");
 		if (errmsg)
@@ -88,11 +89,9 @@ int	cmd_set_output_file(t_command_invocation *command)
 		filepath = expand_redirect_filepath((char *)red->filepath);
 		if (!filepath)
 			return (ERROR);
-		flag_open = 0;
+		flag_open = O_TRUNC;
 		if (red->is_append)
-			flag_open |= O_APPEND;
-		else
-			flag_open |= O_TRUNC;
+			flag_open = O_APPEND;
 		fd = open(filepath, O_WRONLY | O_CREAT | flag_open,
 				S_IRUSR | S_IWUSR | S_IRGRP | S_IWGRP | S_IROTH);
 		if (fd == -1)

--- a/cmd_exec_command.c
+++ b/cmd_exec_command.c
@@ -1,5 +1,39 @@
-#include "env.h"
-#include "execution.h"
+#include "minishell.h"
+
+/*
+ * リダイレクション用に渡された文字列の環境変数展開を行う.
+ *
+ * 環境変数展開を行った結果, 文字列が0個や2つ以上の場合はエラーを表すNULLを返す.
+ * エラーの場合, エラーメッセージをstderrに出力する.
+ *
+ * red_target: リダイレクション先の文字列
+ *
+ * return: 環境変数展開などが完了した文字列.
+ *   展開した結果文字列が2つ以上の場合はエラーなのでNULLを返す.
+ */
+char *expand_redirect_filepath(char *red_target)
+{
+	char	*expanded_str;
+	char	**splitted_expanded_str;
+	char	*errmsg;
+	char	*filepath;
+
+	expanded_str = expand_env_var(red_target);
+	splitted_expanded_str = split_expanded_str(expanded_str);
+	free(expanded_str);
+	if (!splitted_expanded_str || ptrarr_len((void **)splitted_expanded_str) != 1)
+	{
+		errmsg = ft_strjoin(red_target, ": ambiguous redirect\n");
+		if (errmsg)
+			put_err_msg(errmsg);
+		free_ptrarr((void **)splitted_expanded_str);
+		free(errmsg);
+		return (NULL);
+	}
+	filepath = ft_strdup(splitted_expanded_str[0]);
+	free_ptrarr((void **)splitted_expanded_str);
+	return (filepath);
+}
 
 /*
  * open input file as stdin if command->input_file_path is exist
@@ -13,12 +47,16 @@ int	cmd_set_input_file(t_command_invocation *command)
 	int					fd;
 	t_list				*current;
 	t_cmd_redirection	*red;
+	char				*filepath;
 
 	current = command->input_redirections;
 	while (current)
 	{
 		red = (t_cmd_redirection *)current->content;
-		fd = open(red->filepath, O_RDONLY);
+		filepath = expand_redirect_filepath((char *)red->filepath);
+		if (!filepath)
+			return (ERROR);
+		fd = open(filepath, O_RDONLY);
 		if (fd == -1)
 			return (put_err_msg_and_ret("error open()"));
 		if (!current->next && dup2(fd, STDIN_FILENO) == -1)
@@ -41,11 +79,15 @@ int	cmd_set_output_file(t_command_invocation *command)
 	t_list				*current;
 	t_cmd_redirection	*red;
 	int					flag_open;
+	char				*filepath;
 
 	current = command->output_redirections;
 	while (current)
 	{
 		red = (t_cmd_redirection *)current->content;
+		filepath = expand_redirect_filepath((char *)red->filepath);
+		if (!filepath)
+			return (ERROR);
 		flag_open = 0;
 		if (red->is_append)
 			flag_open |= O_APPEND;

--- a/convert_ast2cmdinvo.c
+++ b/convert_ast2cmdinvo.c
@@ -43,14 +43,15 @@ int	cmd_process_redirection_node(t_parse_node_redirection *redirection_node,
 	char		**splitted_env_val;
 
 	redirection_type = redirection_node->type;
-	splitted_env_val = expand_string_node(redirection_node->string_node->content.string);
+	splitted_env_val = expand_string_node(
+			redirection_node->string_node->content.string);
 	if (!splitted_env_val || ptrarr_len((void **)splitted_env_val) != 1)
 	{
-		free_ptrarr((void**)splitted_env_val);
+		free_ptrarr((void **)splitted_env_val);
 		return (ERROR);
 	}
 	text = ft_strdup(splitted_env_val[0]);
-	free_ptrarr((void**)splitted_env_val);
+	free_ptrarr((void **)splitted_env_val);
 	if (!text)
 		return (ERROR);
 	if (redirection_type == TOKTYPE_INPUT_REDIRECTION)

--- a/convert_ast2cmdinvo.c
+++ b/convert_ast2cmdinvo.c
@@ -40,9 +40,17 @@ int	cmd_process_redirection_node(t_parse_node_redirection *redirection_node,
 {
 	int			redirection_type;
 	const char	*text;
+	char		**splitted_env_val;
 
 	redirection_type = redirection_node->type;
-	text = ft_strdup(redirection_node->string_node->content.string->text);
+	splitted_env_val = expand_string_node(redirection_node->string_node->content.string);
+	if (!splitted_env_val || ptrarr_len((void **)splitted_env_val) != 1)
+	{
+		free_ptrarr((void**)splitted_env_val);
+		return (ERROR);
+	}
+	text = ft_strdup(splitted_env_val[0]);
+	free_ptrarr((void**)splitted_env_val);
 	if (!text)
 		return (ERROR);
 	if (redirection_type == TOKTYPE_INPUT_REDIRECTION)

--- a/convert_ast2cmdinvo.c
+++ b/convert_ast2cmdinvo.c
@@ -30,6 +30,8 @@ int	cmd_process_string_node(t_parse_node_string *string_node,
 /* set values of command->input_file_path or output_file_path
 ** based on redirection_node
 **
+** bashの挙動に合わせるため環境変数展開はここで行わず, 実行する直前のタイミングで行う
+**
 ** redirection ::=
 **       "<" string
 **     | ">" string
@@ -40,18 +42,9 @@ int	cmd_process_redirection_node(t_parse_node_redirection *redirection_node,
 {
 	int			redirection_type;
 	const char	*text;
-	char		**splitted_env_val;
 
 	redirection_type = redirection_node->type;
-	splitted_env_val = expand_string_node(
-			redirection_node->string_node->content.string);
-	if (!splitted_env_val || ptrarr_len((void **)splitted_env_val) != 1)
-	{
-		free_ptrarr((void **)splitted_env_val);
-		return (ERROR);
-	}
-	text = ft_strdup(splitted_env_val[0]);
-	free_ptrarr((void **)splitted_env_val);
+	text = string_node2string(redirection_node->string_node->content.string);
 	if (!text)
 		return (ERROR);
 	if (redirection_type == TOKTYPE_INPUT_REDIRECTION)

--- a/test/ast2cmdinvo_test.c
+++ b/test/ast2cmdinvo_test.c
@@ -731,7 +731,7 @@ int main()
 		/* テスト */
 		t_command_invocation *actual = cmd_ast_cmd2cmdinvo(node->content.command);
 		t_command_invocation *expected = cmd_init_cmdinvo((const char **)ft_split("echo hello", ' '));
-		cmd_add_outredirect(expected, "$ABC", false);
+		cmd_add_outredirect(expected, ft_strdup("$ABC"), false);
 		CHECK(actual);
 		check_cmdinvo(actual, expected);
 
@@ -766,7 +766,7 @@ int main()
 		/* テスト */
 		t_command_invocation *actual = cmd_ast_cmd2cmdinvo(node->content.command);
 		t_command_invocation *expected = cmd_init_cmdinvo((const char **)ft_split("echo hello", ' '));
-		cmd_add_outredirect(expected, "hoge$ABC", false);
+		cmd_add_outredirect(expected, ft_strdup("hoge$ABC"), false);
 		CHECK(actual);
 		check_cmdinvo(actual, expected);
 

--- a/test/ast2cmdinvo_test.c
+++ b/test/ast2cmdinvo_test.c
@@ -705,6 +705,134 @@ int main()
 		unsetenv("DEF");
 	}
 
+	TEST_SECTION("cmd_ast_cmd2cmdinvo リダイレクション 環境変数");
+	{
+		/* 準備 */
+		setenv("ABC", "abc", 1);
+		t_parse_buffer	buf;
+		init_buf_with_string(&buf, "echo hello > $ABC \n");
+		t_token	tok;
+
+		lex_get_token(&buf, &tok);
+
+		t_parse_ast *node = parse_command(&buf, &tok);
+        CHECK_EQ(node->type, ASTNODE_COMMAND);
+		CHECK_EQ(node->content.command->arguments_node->type, ASTNODE_ARGUMENTS);
+		t_parse_node_arguments *args_node = node->content.command->arguments_node->content.arguments;
+		CHECK_EQ(args_node->string_node->content.string->type, TOKTYPE_EXPANDABLE);
+		CHECK_EQ_STR(args_node->string_node->content.string->text, "echo");
+		args_node = args_node->rest_node->content.arguments;
+		CHECK_EQ(args_node->string_node->content.string->type, TOKTYPE_EXPANDABLE);
+		CHECK_EQ_STR(args_node->string_node->content.string->text, "hello");
+		args_node = args_node->rest_node->content.arguments;
+		CHECK_EQ(args_node->redirection_node->content.redirection->type, TOKTYPE_OUTPUT_REDIRECTION);
+		CHECK_EQ_STR(args_node->redirection_node->content.redirection->string_node->content.string->text, "$ABC");
+
+		/* テスト */
+		t_command_invocation *actual = cmd_ast_cmd2cmdinvo(node->content.command);
+		t_command_invocation *expected = cmd_init_cmdinvo((const char **)ft_split("echo hello", ' '));
+		cmd_add_outredirect(expected, "abc", false);
+		CHECK(actual);
+		check_cmdinvo(actual, expected);
+
+		cmd_free_cmdinvo(actual);
+		cmd_free_cmdinvo(expected);
+		unsetenv("ABC");
+	}
+
+	TEST_SECTION("cmd_ast_cmd2cmdinvo リダイレクション 環境変数両端空白あり");
+	{
+		/* 準備 */
+		setenv("ABC", " abc ", 1);
+		t_parse_buffer	buf;
+		init_buf_with_string(&buf, "echo hello > $ABC \n");
+		t_token	tok;
+
+		lex_get_token(&buf, &tok);
+
+		t_parse_ast *node = parse_command(&buf, &tok);
+        CHECK_EQ(node->type, ASTNODE_COMMAND);
+		CHECK_EQ(node->content.command->arguments_node->type, ASTNODE_ARGUMENTS);
+		t_parse_node_arguments *args_node = node->content.command->arguments_node->content.arguments;
+		CHECK_EQ(args_node->string_node->content.string->type, TOKTYPE_EXPANDABLE);
+		CHECK_EQ_STR(args_node->string_node->content.string->text, "echo");
+		args_node = args_node->rest_node->content.arguments;
+		CHECK_EQ(args_node->string_node->content.string->type, TOKTYPE_EXPANDABLE);
+		CHECK_EQ_STR(args_node->string_node->content.string->text, "hello");
+		args_node = args_node->rest_node->content.arguments;
+		CHECK_EQ(args_node->redirection_node->content.redirection->type, TOKTYPE_OUTPUT_REDIRECTION);
+		CHECK_EQ_STR(args_node->redirection_node->content.redirection->string_node->content.string->text, "$ABC");
+
+		/* テスト */
+		t_command_invocation *actual = cmd_ast_cmd2cmdinvo(node->content.command);
+		t_command_invocation *expected = cmd_init_cmdinvo((const char **)ft_split("echo hello", ' '));
+		cmd_add_outredirect(expected, "abc", false);
+		CHECK(actual);
+		check_cmdinvo(actual, expected);
+
+		cmd_free_cmdinvo(actual);
+		cmd_free_cmdinvo(expected);
+		unsetenv("ABC");
+	}
+
+	TEST_SECTION("cmd_ast_cmd2cmdinvo リダイレクション 環境変数途中空白あり");
+	{
+		/* 準備 */
+		setenv("ABC", "abc def", 1);
+		t_parse_buffer	buf;
+		init_buf_with_string(&buf, "echo hello > $ABC \n");
+		t_token	tok;
+
+		lex_get_token(&buf, &tok);
+
+		t_parse_ast *node = parse_command(&buf, &tok);
+        CHECK_EQ(node->type, ASTNODE_COMMAND);
+		CHECK_EQ(node->content.command->arguments_node->type, ASTNODE_ARGUMENTS);
+		t_parse_node_arguments *args_node = node->content.command->arguments_node->content.arguments;
+		CHECK_EQ(args_node->string_node->content.string->type, TOKTYPE_EXPANDABLE);
+		CHECK_EQ_STR(args_node->string_node->content.string->text, "echo");
+		args_node = args_node->rest_node->content.arguments;
+		CHECK_EQ(args_node->string_node->content.string->type, TOKTYPE_EXPANDABLE);
+		CHECK_EQ_STR(args_node->string_node->content.string->text, "hello");
+		args_node = args_node->rest_node->content.arguments;
+		CHECK_EQ(args_node->redirection_node->content.redirection->type, TOKTYPE_OUTPUT_REDIRECTION);
+		CHECK_EQ_STR(args_node->redirection_node->content.redirection->string_node->content.string->text, "$ABC");
+
+		/* テスト */
+		t_command_invocation *actual = cmd_ast_cmd2cmdinvo(node->content.command);
+		CHECK(!actual);  // エラー
+		unsetenv("ABC");
+	}
+
+	TEST_SECTION("cmd_ast_cmd2cmdinvo リダイレクション 環境変数空文字列");
+	{
+		/* 準備 */
+		setenv("ABC", "", 1);
+		t_parse_buffer	buf;
+		init_buf_with_string(&buf, "echo hello > $ABC \n");
+		t_token	tok;
+
+		lex_get_token(&buf, &tok);
+
+		t_parse_ast *node = parse_command(&buf, &tok);
+        CHECK_EQ(node->type, ASTNODE_COMMAND);
+		CHECK_EQ(node->content.command->arguments_node->type, ASTNODE_ARGUMENTS);
+		t_parse_node_arguments *args_node = node->content.command->arguments_node->content.arguments;
+		CHECK_EQ(args_node->string_node->content.string->type, TOKTYPE_EXPANDABLE);
+		CHECK_EQ_STR(args_node->string_node->content.string->text, "echo");
+		args_node = args_node->rest_node->content.arguments;
+		CHECK_EQ(args_node->string_node->content.string->type, TOKTYPE_EXPANDABLE);
+		CHECK_EQ_STR(args_node->string_node->content.string->text, "hello");
+		args_node = args_node->rest_node->content.arguments;
+		CHECK_EQ(args_node->redirection_node->content.redirection->type, TOKTYPE_OUTPUT_REDIRECTION);
+		CHECK_EQ_STR(args_node->redirection_node->content.redirection->string_node->content.string->text, "$ABC");
+
+		/* テスト */
+		t_command_invocation *actual = cmd_ast_cmd2cmdinvo(node->content.command);
+		CHECK(actual);  // エラー
+		unsetenv("ABC");
+	}
+
 	TEST_SECTION("cmd_ast_cmd2cmdinvo 存在しない環境変数");
 	{
 		/* 準備 */

--- a/test/ast2cmdinvo_test.c
+++ b/test/ast2cmdinvo_test.c
@@ -829,8 +829,35 @@ int main()
 
 		/* テスト */
 		t_command_invocation *actual = cmd_ast_cmd2cmdinvo(node->content.command);
-		CHECK(actual);  // エラー
+		CHECK(!actual);  // エラー
 		unsetenv("ABC");
+	}
+
+	TEST_SECTION("cmd_ast_cmd2cmdinvo リダイレクション 存在しない環境変数");
+	{
+		/* 準備 */
+		t_parse_buffer	buf;
+		init_buf_with_string(&buf, "echo hello > $DONTEXISTS \n");
+		t_token	tok;
+
+		lex_get_token(&buf, &tok);
+
+		t_parse_ast *node = parse_command(&buf, &tok);
+        CHECK_EQ(node->type, ASTNODE_COMMAND);
+		CHECK_EQ(node->content.command->arguments_node->type, ASTNODE_ARGUMENTS);
+		t_parse_node_arguments *args_node = node->content.command->arguments_node->content.arguments;
+		CHECK_EQ(args_node->string_node->content.string->type, TOKTYPE_EXPANDABLE);
+		CHECK_EQ_STR(args_node->string_node->content.string->text, "echo");
+		args_node = args_node->rest_node->content.arguments;
+		CHECK_EQ(args_node->string_node->content.string->type, TOKTYPE_EXPANDABLE);
+		CHECK_EQ_STR(args_node->string_node->content.string->text, "hello");
+		args_node = args_node->rest_node->content.arguments;
+		CHECK_EQ(args_node->redirection_node->content.redirection->type, TOKTYPE_OUTPUT_REDIRECTION);
+		CHECK_EQ_STR(args_node->redirection_node->content.redirection->string_node->content.string->text, "$DONTEXISTS");
+
+		/* テスト */
+		t_command_invocation *actual = cmd_ast_cmd2cmdinvo(node->content.command);
+		CHECK(!actual);  // エラー
 	}
 
 	TEST_SECTION("cmd_ast_cmd2cmdinvo 存在しない環境変数");


### PR DESCRIPTION
Fix #62 

`echo "Hello" > $ABC` のようにリダイレクション先の文字列に環境変数が入っている場合の処理を追加.

Bashの実装ではリダイレクション先の環境変数展開はコマンド実行直前に行っているようだった. 自分の実装で言うと, ASTから`cmd_invo` への変換のタイミングで環境変数展開をするのではなく, `cmd_exec_command()` のタイミングで環境変数展開をしているものと考えた.

もしかしてリダイレクションに限らずコマンドの引数なども同じタイミングで環境変数展開されているのだろうか?