### PR TITLE
最初のコマンドのパイプの処理を修正

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,14 +9,15 @@ HEADER_FILES = minishell.h
 SRCS = cmd_cmd_invocation.c cmd_cmd_invocation2.c cmd_exec_command.c	\
 	cmd_exec_commands.c cmd_pid.c cmd_pipe.c convert_ast2cmdinvo.c		\
 	env.c exec.c lexer1.c lexer2.c minishell.c parse1.c parse2.c		\
-	parse_utils.c parse_utils2.c path.c
+	parse_utils.c parse_utils2.c path.c \
+	string_node2string.c expand_env_var.c expand_string_node.c split_expanded_str.c
 OBJS = $(SRCS:.c=.o)
 
 all: $(NAME)
 
 $(NAME): ${HEADER_FILES} ${OBJS}
 	$(LIBFT_MAKE)
-	$(CC) -g -fsanitize=address -o $(NAME) $(SRCS) $(LIBFT_LIB) -lbsd
+	$(CC) -g -fsanitize=address -o $(NAME) $(OBJS) $(LIBFT_LIB) -lbsd
 
 clean:
 	$(LIBFT_MAKE) clean

--- a/cmd_exec_command.c
+++ b/cmd_exec_command.c
@@ -73,7 +73,7 @@ int	cmd_set_output_file(t_command_invocation *command)
 void	cmd_exec_command(t_command_invocation *command,
 	int pipe_prev_fd[2], int pipe_fd[2])
 {
-	if (pipe_prev_fd)
+	if (pipe_prev_fd[1] >= 0)  // 最初のコマンド時, pipe_prev_fd[1]は-1
 	{
 		close(pipe_prev_fd[1]);
 		if (dup2(pipe_prev_fd[0], STDIN_FILENO) == -1)

--- a/cmd_exec_command.c
+++ b/cmd_exec_command.c
@@ -73,7 +73,7 @@ int	cmd_set_output_file(t_command_invocation *command)
 void	cmd_exec_command(t_command_invocation *command,
 	int pipe_prev_fd[2], int pipe_fd[2])
 {
-	if (pipe_prev_fd[1] >= 0)  // 最初のコマンド時, pipe_prev_fd[1]は-1
+	if (pipe_prev_fd[1] >= 0)
 	{
 		close(pipe_prev_fd[1]);
 		if (dup2(pipe_prev_fd[0], STDIN_FILENO) == -1)


### PR DESCRIPTION
Fix: #68 

```
minish > cat
cat: -: Bad file descriptor
cat: closing standard input: Bad file descriptor
```

このような表示が出ていた. これを修正した.

原因は最初のコマンドで存在しないはずの前回のパイプをstdinにdupしようとしていたからだった.