### PR TITLE
シグナルハンドリングの追加

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,14 +9,15 @@ HEADER_FILES = minishell.h
 SRCS = cmd_cmd_invocation.c cmd_cmd_invocation2.c cmd_exec_command.c	\
 	cmd_exec_commands.c cmd_pid.c cmd_pipe.c convert_ast2cmdinvo.c		\
 	env.c exec.c lexer1.c lexer2.c minishell.c parse1.c parse2.c		\
-	parse_utils.c parse_utils2.c path.c
+	parse_utils.c parse_utils2.c path.c \
+	string_node2string.c expand_env_var.c expand_string_node.c split_expanded_str.c
 OBJS = $(SRCS:.c=.o)
 
 all: $(NAME)
 
 $(NAME): ${HEADER_FILES} ${OBJS}
 	$(LIBFT_MAKE)
-	$(CC) -g -fsanitize=address -o $(NAME) $(SRCS) $(LIBFT_LIB) -lbsd
+	$(CC) -g -fsanitize=address -o $(NAME) $(OBJS) $(LIBFT_LIB) -lbsd
 
 clean:
 	$(LIBFT_MAKE) clean

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ SRCS = cmd_cmd_invocation.c cmd_cmd_invocation2.c cmd_exec_command.c	\
 	env.c exec.c lexer1.c lexer2.c minishell.c parse1.c parse2.c		\
 	parse_utils.c parse_utils2.c path.c \
 	string_node2string.c expand_env_var.c expand_string_node.c split_expanded_str.c \
-	cmd_status.c
+	cmd_status.c signal.c
 
 OBJS = $(SRCS:.c=.o)
 

--- a/cmd_exec_command.c
+++ b/cmd_exec_command.c
@@ -114,7 +114,7 @@ int	cmd_set_output_file(t_command_invocation *command)
 void	cmd_exec_command(t_command_invocation *command,
 	int pipe_prev_fd[2], int pipe_fd[2])
 {
-	set_signal_handlers(SIG_DFL);
+	set_sighandlers(SIG_DFL);
 	if (pipe_prev_fd[1] >= 0)
 	{
 		close(pipe_prev_fd[1]);

--- a/cmd_exec_command.c
+++ b/cmd_exec_command.c
@@ -114,6 +114,7 @@ int	cmd_set_output_file(t_command_invocation *command)
 void	cmd_exec_command(t_command_invocation *command,
 	int pipe_prev_fd[2], int pipe_fd[2])
 {
+	set_signal_handlers(SIG_DFL);
 	if (pipe_prev_fd[1] >= 0)
 	{
 		close(pipe_prev_fd[1]);

--- a/minishell.c
+++ b/minishell.c
@@ -82,7 +82,7 @@ int	main(int argc, char **argv)
 	printf("Welcome to Minishell\n");
 	while (1)
 	{
-		printf("minish > ");
+		printf(PROMPT);
 		fflush(stdout);
 		lex_get_token(&buf, &tok);
 		cmdline = parse_command_line(&buf, &tok);

--- a/minishell.c
+++ b/minishell.c
@@ -77,7 +77,7 @@ int	main(int argc, char **argv)
 	if (argc == 3
 		&& argv[1][0] == '-' && argv[1][1] == 'c' && argv[1][2] == '\0')
 		return (do_command(argv[2]));
-	setup_signal_handlers();
+	set_shell_sighandlers();
 	init_buffer_with_string(&buf, "");
 	printf("Welcome to Minishell\n");
 	while (1)

--- a/minishell.c
+++ b/minishell.c
@@ -82,7 +82,7 @@ int	main(int argc, char **argv)
 	printf("Welcome to Minishell\n");
 	while (1)
 	{
-		printf(PROMPT);
+		printf("\r"PROMPT);
 		fflush(stdout);
 		lex_get_token(&buf, &tok);
 		cmdline = parse_command_line(&buf, &tok);

--- a/minishell.c
+++ b/minishell.c
@@ -76,8 +76,7 @@ int	main(int argc, char **argv)
 	if (argc == 3
 		&& argv[1][0] == '-' && argv[1][1] == 'c' && argv[1][2] == '\0')
 		return (do_command(argv[2]));
-	if (setup_signal_handlers())
-		return (put_err_msg_and_ret("signal() failed"));
+	setup_signal_handlers();
 	init_buffer_with_string(&buf, "");
 	printf("Welcome to Minishell\n");
 	while (1)

--- a/minishell.c
+++ b/minishell.c
@@ -43,6 +43,8 @@ int	main(int argc, char **argv)
 	t_parse_ast				*seqcmd;
 
 	init_buffer(&buf);
+	if (setup_signal_handlers())
+		return (put_err_msg_and_ret("signal() failed"));
 	printf("Welcome Minishell\n");
 	while (1)
 	{

--- a/minishell.c
+++ b/minishell.c
@@ -73,11 +73,11 @@ int	main(int argc, char **argv)
 	t_token					tok;
 	t_parse_ast				*seqcmd;
 
-	if (setup_signal_handlers())
-		return (put_err_msg_and_ret("signal() failed"));
 	if (argc == 3
 		&& argv[1][0] == '-' && argv[1][1] == 'c' && argv[1][2] == '\0')
 		return (do_command(argv[2]));
+	if (setup_signal_handlers())
+		return (put_err_msg_and_ret("signal() failed"));
 	init_buffer_with_string(&buf, "");
 	printf("Welcome to Minishell\n");
 	while (1)

--- a/minishell.c
+++ b/minishell.c
@@ -74,8 +74,7 @@ int	main(int argc, char **argv)
 	t_token					tok;
 	t_parse_ast				*seqcmd;
 
-	if (argc == 3
-		&& argv[1][0] == '-' && argv[1][1] == 'c' && argv[1][2] == '\0')
+	if (argc == 3 && ft_strncmp(argv[1], "-c", 3) == 0)
 		return (do_command(argv[2]));
 	set_shell_sighandlers();
 	init_buffer_with_string(&buf, "");

--- a/minishell.h
+++ b/minishell.h
@@ -19,6 +19,7 @@ char					*string_node2string(t_parse_node_string *string_node);
 char					**expand_string_node(t_parse_node_string *string_node);
 char					**split_expanded_str(char *str);
 char					**expand_string_node(t_parse_node_string *string_node);
-void					setup_signal_handlers(void);
+void					set_shell_sighandlers(void);
+void					set_signal_handlers(__sighandler_t sighandler);
 
 #endif

--- a/minishell.h
+++ b/minishell.h
@@ -20,6 +20,6 @@ char					**expand_string_node(t_parse_node_string *string_node);
 char					**split_expanded_str(char *str);
 char					**expand_string_node(t_parse_node_string *string_node);
 void					set_shell_sighandlers(void);
-void					set_signal_handlers(__sighandler_t sighandler);
+void					set_sighandlers(__sighandler_t sighandler);
 
 #endif

--- a/minishell.h
+++ b/minishell.h
@@ -17,5 +17,6 @@ char					*string_node2string(t_parse_node_string *string_node);
 char					**expand_string_node(t_parse_node_string *string_node);
 char					**split_expanded_str(char *str);
 char					**expand_string_node(t_parse_node_string *string_node);
+int						setup_signal_handlers(void);
 
 #endif

--- a/minishell.h
+++ b/minishell.h
@@ -10,6 +10,8 @@
 # include "lexer.h"
 # include "parse.h"
 
+# define PROMPT "minish > "
+
 // AST to command_invocation
 t_command_invocation	*cmd_ast_pipcmds2cmdinvo(t_parse_node_pipcmds *pipcmds);
 t_command_invocation	*cmd_ast_cmd2cmdinvo(t_parse_node_command *cmd_node);

--- a/minishell.h
+++ b/minishell.h
@@ -19,6 +19,6 @@ char					*string_node2string(t_parse_node_string *string_node);
 char					**expand_string_node(t_parse_node_string *string_node);
 char					**split_expanded_str(char *str);
 char					**expand_string_node(t_parse_node_string *string_node);
-int						setup_signal_handlers(void);
+void					setup_signal_handlers(void);
 
 #endif

--- a/signal.c
+++ b/signal.c
@@ -1,8 +1,15 @@
 #include "minishell.h"
 
+static void sigint_sighandler(int sig)
+{
+	printf("receive SIGINT\n");
+}
+
 int	setup_signal_handlers(void)
 {
 	if (signal(SIGQUIT, SIG_IGN) == SIG_ERR)
+		return (-1);
+	if (signal(SIGINT, sigint_sighandler) == SIG_ERR)
 		return (-1);
 	return (0);
 }

--- a/signal.c
+++ b/signal.c
@@ -6,12 +6,11 @@ static void sigint_sighandler(int sig)
 	set_status(128 + sig);
 }
 
-int	setup_signal_handlers(void)
+void	setup_signal_handlers(void)
 {
 	if (signal(SIGQUIT, SIG_IGN) == SIG_ERR)
-		return (-1);
+		exit(1);
 	if (signal(SIGINT, sigint_sighandler) == SIG_ERR)
-		return (-1);
-	return (0);
+		exit(1);
 }
 

--- a/signal.c
+++ b/signal.c
@@ -2,7 +2,7 @@
 
 static void sigint_sighandler(int sig)
 {
-	write(STDIN_FILENO, "\n", 1);
+	ft_putstr_fd("\n\bminish > ", STDOUT_FILENO);
 	set_status(128 + sig);
 }
 

--- a/signal.c
+++ b/signal.c
@@ -6,6 +6,12 @@ static void	sigint_sighandler(int sig)
 	set_status(128 + sig);
 }
 
+static void	sigquit_sighandler(int sig)
+{
+	(void)sig;
+	ft_putstr_fd("\b\b  \b\b", STDOUT_FILENO);
+}
+
 void	set_sighandlers(__sighandler_t sighandler)
 {
 	if (signal(SIGQUIT, sighandler) == SIG_ERR
@@ -25,7 +31,7 @@ void	set_sighandlers(__sighandler_t sighandler)
  */
 void	set_shell_sighandlers(void)
 {
-	if (signal(SIGQUIT, SIG_IGN) == SIG_ERR
+	if (signal(SIGQUIT, sigquit_sighandler) == SIG_ERR
 		|| signal(SIGINT, sigint_sighandler) == SIG_ERR)
 	{
 		printf("signal() failed\n");

--- a/signal.c
+++ b/signal.c
@@ -8,10 +8,12 @@ static void	sigint_sighandler(int sig)
 
 void	set_sighandlers(__sighandler_t sighandler)
 {
-	if (signal(SIGQUIT, sighandler) == SIG_ERR)
+	if (signal(SIGQUIT, sighandler) == SIG_ERR
+		|| signal(SIGINT, sighandler) == SIG_ERR)
+	{
+		printf("signal() failed\n");
 		exit(1);
-	if (signal(SIGINT, sighandler) == SIG_ERR)
-		exit(1);
+	}
 }
 
 /*
@@ -23,8 +25,10 @@ void	set_sighandlers(__sighandler_t sighandler)
  */
 void	set_shell_sighandlers(void)
 {
-	if (signal(SIGQUIT, SIG_IGN) == SIG_ERR)
+	if (signal(SIGQUIT, SIG_IGN) == SIG_ERR
+		|| signal(SIGINT, sigint_sighandler) == SIG_ERR)
+	{
+		printf("signal() failed\n");
 		exit(1);
-	if (signal(SIGINT, sigint_sighandler) == SIG_ERR)
-		exit(1);
+	}
 }

--- a/signal.c
+++ b/signal.c
@@ -6,7 +6,22 @@ static void sigint_sighandler(int sig)
 	set_status(128 + sig);
 }
 
-void	setup_signal_handlers(void)
+void	set_signal_handlers(__sighandler_t sighandler)
+{
+	if (signal(SIGQUIT, sighandler) == SIG_ERR)
+		exit(1);
+	if (signal(SIGINT, sighandler) == SIG_ERR)
+		exit(1);
+}
+
+/*
+ * シェルでのシグナルハンドラーを設定する
+ *
+ * 具体的には以下のようなハンドラーを設定する
+ * - SIGQUIT: 無視
+ * - SIGINT: 改行してプロンプトを表示
+ */
+void	set_shell_sighandlers(void)
 {
 	if (signal(SIGQUIT, SIG_IGN) == SIG_ERR)
 		exit(1);

--- a/signal.c
+++ b/signal.c
@@ -1,6 +1,6 @@
 #include "minishell.h"
 
-static void sigint_sighandler(int sig)
+static void	sigint_sighandler(int sig)
 {
 	ft_putstr_fd("\n\r"PROMPT, STDOUT_FILENO);
 	set_status(128 + sig);
@@ -28,4 +28,3 @@ void	set_shell_sighandlers(void)
 	if (signal(SIGINT, sigint_sighandler) == SIG_ERR)
 		exit(1);
 }
-

--- a/signal.c
+++ b/signal.c
@@ -6,7 +6,7 @@ static void	sigint_sighandler(int sig)
 	set_status(128 + sig);
 }
 
-void	set_signal_handlers(__sighandler_t sighandler)
+void	set_sighandlers(__sighandler_t sighandler)
 {
 	if (signal(SIGQUIT, sighandler) == SIG_ERR)
 		exit(1);

--- a/signal.c
+++ b/signal.c
@@ -2,7 +2,8 @@
 
 static void sigint_sighandler(int sig)
 {
-	printf("receive SIGINT\n");
+	write(STDIN_FILENO, "\n", 1);
+	set_status(128 + sig);
 }
 
 int	setup_signal_handlers(void)

--- a/signal.c
+++ b/signal.c
@@ -1,0 +1,9 @@
+#include "minishell.h"
+
+int	setup_signal_handlers(void)
+{
+	if (signal(SIGQUIT, SIG_IGN) == SIG_ERR)
+		return (-1);
+	return (0);
+}
+

--- a/signal.c
+++ b/signal.c
@@ -2,7 +2,7 @@
 
 static void sigint_sighandler(int sig)
 {
-	ft_putstr_fd("\n\b"PROMPT, STDOUT_FILENO);
+	ft_putstr_fd("\n\r"PROMPT, STDOUT_FILENO);
 	set_status(128 + sig);
 }
 

--- a/signal.c
+++ b/signal.c
@@ -2,7 +2,7 @@
 
 static void sigint_sighandler(int sig)
 {
-	ft_putstr_fd("\n\bminish > ", STDOUT_FILENO);
+	ft_putstr_fd("\n\b"PROMPT, STDOUT_FILENO);
 	set_status(128 + sig);
 }
 

--- a/test/Makefile
+++ b/test/Makefile
@@ -21,7 +21,8 @@ SRCS = ../env.c \
 	   ../split_expanded_str.c \
 	   ../string_node2string.c \
 	   ../expand_string_node.c \
-	   ../cmd_status.c
+	   ../cmd_status.c \
+	   ../signal.c
 HEADERS = ../env.h \
 		  ../parse.h \
 		  ../execution.h \


### PR DESCRIPTION
Close #37 

シェルでのシグナルハンドリングを追加しました.

課題では ctrl-C (SIGINT) と ctrl-\\ (SIGQUIT) に対応すれば良いと書いてあり, 以下の要件を満たしていればよいのかなと思いました.

シェル上
- SIGINT: 改行して新しいプロンプト表示
- SIGQUIT: 無視

実行コマンド(子プロセス):
- SIGINT: デフォルト動作
- SIGQUIT: デフォルト動作