### PR TITLE
ファイルディスクリプタ付きのリダイレクションのパーサ。

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ LIBFT_LIB = ./libft/libft.a
 HEADER_FILES = minishell.h
 SRCS = cmd_cmd_invocation.c cmd_cmd_invocation2.c cmd_exec_command.c		\
 	cmd_exec_commands.c cmd_pipe.c cmd_redirection.c convert_ast2cmdinvo.c	\
-	env.c exec.c lexer1.c lexer2.c minishell.c parse1.c parse2.c			\
+	env.c exec.c lexer1.c lexer2.c lexer3.c minishell.c parse1.c parse2.c	\
 	parse_utils.c parse_utils2.c path.c g_cwd.c string_node2string.c		\
 	expand_env_var.c expand_string_node.c split_expanded_str.c				\
 	cmd_status.c signal.c env_setter.c minishell_error_msg.c				\

--- a/lexer.h
+++ b/lexer.h
@@ -36,5 +36,6 @@ int		lex_get_spaces(t_parse_buffer *buf, t_token *result, int ch);
 int		lex_get_symbols(t_parse_buffer *buf, t_token *result, int ch);
 int		lex_get_quoted(t_parse_buffer *buf, t_token *result, int ch);
 int		lex_get_token(t_parse_buffer *buf, t_token *result);
+int		lex_check_redirection_with_fd(t_parse_buffer *buf, t_token *result);
 
 #endif

--- a/lexer1.c
+++ b/lexer1.c
@@ -1,6 +1,7 @@
 #include <stdio.h>
 #include <unistd.h>
 
+#include "libft/libft.h"
 #include "parse.h"
 
 int	lex_getc(t_parse_buffer *buf)
@@ -27,7 +28,10 @@ int	lex_get_symbols(t_parse_buffer *buf, t_token *result, int ch)
 	else if (ch == '|')
 		result->type = TOKTYPE_PIPE;
 	else if (ch == '<')
+	{
 		result->type = TOKTYPE_INPUT_REDIRECTION;
+		result->length = 0;
+	}
 	else if (ch == '>')
 	{
 		ch = lex_getc(buf);
@@ -39,6 +43,7 @@ int	lex_get_symbols(t_parse_buffer *buf, t_token *result, int ch)
 			if (ch != EOF)
 				lex_ungetc(buf);
 		}
+		result->length = 1;
 	}
 	else
 		return (0);
@@ -78,6 +83,8 @@ int	lex_get_token(t_parse_buffer *buf, t_token *result)
 		result->type = TOKTYPE_EXPANDABLE;
 		lex_ungetc(buf);
 		ret = lex_read_word(buf, result);
+		if (ret)
+			lex_check_redirection_with_fd(buf, result);
 	}
 	return (ret);
 }

--- a/lexer3.c
+++ b/lexer3.c
@@ -1,0 +1,25 @@
+#include "libft/libft.h"
+#include "parse.h"
+
+int	lex_check_redirection_with_fd(t_parse_buffer *buf, t_token *result)
+{
+	int	i;
+	int	ch;
+	int	fd;
+
+	i = 0;
+	while (i < result->length)
+	{
+		if (!ft_isdigit(result->text[i]))
+			return (0);
+		i++;
+	}
+	ch = lex_getc(buf);
+	if (ch == '<' || ch == '>')
+	{
+		fd = ft_atoi(result->text);
+		lex_get_symbols(buf, result, ch);
+		result->length = fd;
+	}
+	return (1);
+}

--- a/parse.h
+++ b/parse.h
@@ -57,6 +57,7 @@ typedef struct s_parse_node_redirection
 {
 	t_parse_ast		*string_node;
 	t_token_type	type;
+	int				fd;
 }	t_parse_node_redirection;
 
 typedef struct s_parse_node_delimiter

--- a/parse2.c
+++ b/parse2.c
@@ -136,12 +136,14 @@ t_parse_ast	*parse_redirection(
 	t_parse_ast					*str_node;
 	t_parse_node_redirection	*redirection;
 	t_token_type				type;
+	int							fd;
 
 	type = tok->type;
 	if (type != TOKTYPE_INPUT_REDIRECTION
 		&& type != TOKTYPE_OUTPUT_REDIRECTION
 		&& type != TOKTYPE_OUTPUT_APPENDING)
 		return (NULL);
+	fd = tok->length;
 	lex_get_token(buf, tok);
 	parse_skip_spaces(buf, tok);
 	str_node = parse_string(buf, tok);
@@ -149,6 +151,7 @@ t_parse_ast	*parse_redirection(
 	{
 		redirection = malloc(sizeof(t_parse_node_redirection));
 		redirection->type = type;
+		redirection->fd = fd;
 		redirection->string_node = str_node;
 		new_node = parse_new_ast_node(ASTNODE_REDIRECTION, redirection);
 		return (new_node);

--- a/test/Makefile
+++ b/test/Makefile
@@ -2,7 +2,7 @@ LIBFT_PATH = ../libft
 LIBFT_MAKE = $(MAKE) -C $(LIBFT_PATH)
 LIBFT_LIB = ../libft/libft.a
 SRCS = 	../env.c ../env_setter.c ../path.c ../g_cwd.c												\
-		../lexer1.c ../lexer2.c																		\
+		../lexer1.c ../lexer2.c ../lexer3.c															\
 		../parse1.c ../parse2.c ../parse_utils.c ../parse_utils2.c									\
 		../exec.c ../cmd_exec_command.c ../cmd_exec_commands.c ../cmd_redirection.c ../cmd_pipe.c	\
 		../cmd_cmd_invocation.c ../cmd_cmd_invocation2.c ../convert_ast2cmdinvo.c					\
@@ -28,10 +28,11 @@ run: parse_test env_test path_test exec_test command_exec_test ast2cmdinvo_test
 	${VALGRIND} ./command_exec_test
 	${VALGRIND} ./ast2cmdinvo_test
 
-SRCS_PARSE = $(wildcard ../lexer*.c ../parse*.c) ../libft/ft_memcpy.c
+SRCS_PARSE = $(wildcard ../lexer*.c ../parse*.c)
 
 parse_test: Makefile parse_test.c test.c test.h $(SRCS_PARSE) ../parse.h
-	gcc -Werror -Wall -Wextra -g -o $@ parse_test.c test.c $(SRCS_PARSE) -L ../libft -lft
+	$(LIBFT_MAKE)
+	gcc -Werror -Wall -Wextra -g -o $@ parse_test.c test.c $(SRCS_PARSE) ${LIBFT_LIB}
 
 env_test: env_test.c ${TEST_UTILS} ${SRCS} ${HEADERS}
 	$(LIBFT_MAKE)

--- a/test/Makefile
+++ b/test/Makefile
@@ -31,7 +31,7 @@ run: parse_test env_test path_test exec_test command_exec_test ast2cmdinvo_test
 SRCS_PARSE = $(wildcard ../lexer*.c ../parse*.c) ../libft/ft_memcpy.c
 
 parse_test: Makefile parse_test.c test.c test.h $(SRCS_PARSE) ../parse.h
-	gcc -Werror -Wall -Wextra -g -o $@ parse_test.c test.c $(SRCS_PARSE)
+	gcc -Werror -Wall -Wextra -g -o $@ parse_test.c test.c $(SRCS_PARSE) -L ../libft -lft
 
 env_test: env_test.c ${TEST_UTILS} ${SRCS} ${HEADERS}
 	$(LIBFT_MAKE)

--- a/test/parse_test.c
+++ b/test/parse_test.c
@@ -32,30 +32,30 @@ void test_lexer()
 		CHECK(!strncmp(tok.text, "cat", 3));
 	}
 
-    TEST_SECTION("lex_get_token デスクリプタ付きのリダイレクト");
-    {
+	TEST_SECTION("lex_get_token デスクリプタ付きのリダイレクト");
+	{
 		t_parse_buffer	buf;
 		init_buf_with_string(&buf, "10< 123> 456>> ");
 		t_token	tok;
 
 		lex_get_token(&buf, &tok);
 		CHECK_EQ(tok.type, TOKTYPE_INPUT_REDIRECTION);
-        CHECK_EQ(tok.length, 10);
+		CHECK_EQ(tok.length, 10);
 
 		lex_get_token(&buf, &tok);
 		CHECK_EQ(tok.type, TOKTYPE_SPACE);
 
 		lex_get_token(&buf, &tok);
 		CHECK_EQ(tok.type, TOKTYPE_OUTPUT_REDIRECTION);
-        CHECK_EQ(tok.length, 123);
+		CHECK_EQ(tok.length, 123);
 
 		lex_get_token(&buf, &tok);
 		CHECK_EQ(tok.type, TOKTYPE_SPACE);
 
 		lex_get_token(&buf, &tok);
 		CHECK_EQ(tok.type, TOKTYPE_OUTPUT_APPENDING);
-        CHECK_EQ(tok.length, 456);
-    }
+		CHECK_EQ(tok.length, 456);
+	}
 
 	TEST_SECTION("lex_get_token クォートなしの場合");
 	{
@@ -89,7 +89,7 @@ void test_lexer()
 
 		lex_get_token(&buf, &tok);
 		CHECK_EQ(tok.type, TOKTYPE_OUTPUT_REDIRECTION);
-        CHECK_EQ(tok.length, 1); /* デフォルトで標準出力 (1) */
+		CHECK_EQ(tok.length, 1); /* デフォルトで標準出力 (1) */
 		lex_get_token(&buf, &tok);
 		CHECK_EQ(tok.type, TOKTYPE_SPACE);
 
@@ -140,7 +140,7 @@ void test_lexer()
 
 		lex_get_token(&buf, &tok);
 		CHECK_EQ(tok.type, TOKTYPE_INPUT_REDIRECTION);
-        CHECK_EQ(tok.length, 0); /* デフォルトで標準入力 (0) */
+		CHECK_EQ(tok.length, 0); /* デフォルトで標準入力 (0) */
 
 		lex_get_token(&buf, &tok);
 		CHECK_EQ(tok.type, TOKTYPE_SPACE);
@@ -324,7 +324,7 @@ void test_parser(void)
 		t_parse_ast *node = parse_redirection(&buf, &tok);
 		CHECK(node);
 		CHECK_EQ(node->type, ASTNODE_REDIRECTION);
-        CHECK_EQ(node->content.redirection->fd, 0);
+		CHECK_EQ(node->content.redirection->fd, 0);
 		CHECK_EQ(node->content.redirection->type, TOKTYPE_INPUT_REDIRECTION);
 		CHECK_EQ_STR(node->content.redirection->string_node
 					->content.string->text, "file");
@@ -341,7 +341,7 @@ void test_parser(void)
 		t_parse_ast *node = parse_redirection(&buf, &tok);
 		CHECK(node);
 		CHECK_EQ(node->type, ASTNODE_REDIRECTION);
-        CHECK_EQ(node->content.redirection->fd, 123);
+		CHECK_EQ(node->content.redirection->fd, 123);
 		CHECK_EQ(node->content.redirection->type, TOKTYPE_INPUT_REDIRECTION);
 		CHECK_EQ_STR(node->content.redirection->string_node
 					->content.string->text, "file");
@@ -358,7 +358,7 @@ void test_parser(void)
 		t_parse_ast *node = parse_redirection(&buf, &tok);
 		CHECK(node);
 		CHECK_EQ(node->type, ASTNODE_REDIRECTION);
-        CHECK_EQ(node->content.redirection->fd, 1);
+		CHECK_EQ(node->content.redirection->fd, 1);
 		CHECK_EQ(node->content.redirection->type, TOKTYPE_OUTPUT_REDIRECTION);
 		CHECK_EQ_STR(node->content.redirection->string_node
 					 ->content.string->text, "file");
@@ -375,7 +375,7 @@ void test_parser(void)
 		t_parse_ast *node = parse_redirection(&buf, &tok);
 		CHECK(node);
 		CHECK_EQ(node->type, ASTNODE_REDIRECTION);
-        CHECK_EQ(node->content.redirection->fd, 123);
+		CHECK_EQ(node->content.redirection->fd, 123);
 		CHECK_EQ(node->content.redirection->type, TOKTYPE_OUTPUT_REDIRECTION);
 		CHECK_EQ_STR(node->content.redirection->string_node
 					 ->content.string->text, "file");
@@ -392,7 +392,7 @@ void test_parser(void)
 		t_parse_ast *node = parse_redirection(&buf, &tok);
 		CHECK(node);
 		CHECK_EQ(node->type, ASTNODE_REDIRECTION);
-        CHECK_EQ(node->content.redirection->fd, 1);
+		CHECK_EQ(node->content.redirection->fd, 1);
 		CHECK_EQ(node->content.redirection->type, TOKTYPE_OUTPUT_APPENDING);
 		CHECK_EQ_STR(node->content.redirection->string_node
 					->content.string->text, "file");
@@ -409,7 +409,7 @@ void test_parser(void)
 		t_parse_ast *node = parse_redirection(&buf, &tok);
 		CHECK(node);
 		CHECK_EQ(node->type, ASTNODE_REDIRECTION);
-        CHECK_EQ(node->content.redirection->fd, 456);
+		CHECK_EQ(node->content.redirection->fd, 456);
 		CHECK_EQ(node->content.redirection->type, TOKTYPE_OUTPUT_APPENDING);
 		CHECK_EQ_STR(node->content.redirection->string_node
 					->content.string->text, "file");

--- a/test/parse_test.c
+++ b/test/parse_test.c
@@ -32,6 +32,31 @@ void test_lexer()
 		CHECK(!strncmp(tok.text, "cat", 3));
 	}
 
+    TEST_SECTION("lex_get_token デスクリプタ付きのリダイレクト");
+    {
+		t_parse_buffer	buf;
+		init_buf_with_string(&buf, "10< 123> 456>> ");
+		t_token	tok;
+
+		lex_get_token(&buf, &tok);
+		CHECK_EQ(tok.type, TOKTYPE_INPUT_REDIRECTION);
+        CHECK_EQ(tok.length, 10);
+
+		lex_get_token(&buf, &tok);
+		CHECK_EQ(tok.type, TOKTYPE_SPACE);
+
+		lex_get_token(&buf, &tok);
+		CHECK_EQ(tok.type, TOKTYPE_OUTPUT_REDIRECTION);
+        CHECK_EQ(tok.length, 123);
+
+		lex_get_token(&buf, &tok);
+		CHECK_EQ(tok.type, TOKTYPE_SPACE);
+
+		lex_get_token(&buf, &tok);
+		CHECK_EQ(tok.type, TOKTYPE_OUTPUT_APPENDING);
+        CHECK_EQ(tok.length, 456);
+    }
+
 	TEST_SECTION("lex_get_token クォートなしの場合");
 	{
 		t_parse_buffer	buf;
@@ -64,6 +89,7 @@ void test_lexer()
 
 		lex_get_token(&buf, &tok);
 		CHECK_EQ(tok.type, TOKTYPE_OUTPUT_REDIRECTION);
+        CHECK_EQ(tok.length, 1); /* デフォルトで標準出力 (1) */
 		lex_get_token(&buf, &tok);
 		CHECK_EQ(tok.type, TOKTYPE_SPACE);
 
@@ -114,6 +140,7 @@ void test_lexer()
 
 		lex_get_token(&buf, &tok);
 		CHECK_EQ(tok.type, TOKTYPE_INPUT_REDIRECTION);
+        CHECK_EQ(tok.length, 0); /* デフォルトで標準入力 (0) */
 
 		lex_get_token(&buf, &tok);
 		CHECK_EQ(tok.type, TOKTYPE_SPACE);
@@ -297,6 +324,24 @@ void test_parser(void)
 		t_parse_ast *node = parse_redirection(&buf, &tok);
 		CHECK(node);
 		CHECK_EQ(node->type, ASTNODE_REDIRECTION);
+        CHECK_EQ(node->content.redirection->fd, 0);
+		CHECK_EQ(node->content.redirection->type, TOKTYPE_INPUT_REDIRECTION);
+		CHECK_EQ_STR(node->content.redirection->string_node
+					->content.string->text, "file");
+	}
+
+	TEST_SECTION("parse_redirection デスクリプタ付き <");
+	{
+		t_parse_buffer	buf;
+		init_buf_with_string(&buf, "123< file\n");
+		t_token	tok;
+
+		lex_get_token(&buf, &tok);
+
+		t_parse_ast *node = parse_redirection(&buf, &tok);
+		CHECK(node);
+		CHECK_EQ(node->type, ASTNODE_REDIRECTION);
+        CHECK_EQ(node->content.redirection->fd, 123);
 		CHECK_EQ(node->content.redirection->type, TOKTYPE_INPUT_REDIRECTION);
 		CHECK_EQ_STR(node->content.redirection->string_node
 					->content.string->text, "file");
@@ -313,6 +358,24 @@ void test_parser(void)
 		t_parse_ast *node = parse_redirection(&buf, &tok);
 		CHECK(node);
 		CHECK_EQ(node->type, ASTNODE_REDIRECTION);
+        CHECK_EQ(node->content.redirection->fd, 1);
+		CHECK_EQ(node->content.redirection->type, TOKTYPE_OUTPUT_REDIRECTION);
+		CHECK_EQ_STR(node->content.redirection->string_node
+					 ->content.string->text, "file");
+	}
+
+	TEST_SECTION("parse_redirection　デスクリプタ付き >");
+	{
+		t_parse_buffer	buf;
+		init_buf_with_string(&buf, "123> file\n");
+		t_token	tok;
+
+		lex_get_token(&buf, &tok);
+
+		t_parse_ast *node = parse_redirection(&buf, &tok);
+		CHECK(node);
+		CHECK_EQ(node->type, ASTNODE_REDIRECTION);
+        CHECK_EQ(node->content.redirection->fd, 123);
 		CHECK_EQ(node->content.redirection->type, TOKTYPE_OUTPUT_REDIRECTION);
 		CHECK_EQ_STR(node->content.redirection->string_node
 					 ->content.string->text, "file");
@@ -329,6 +392,24 @@ void test_parser(void)
 		t_parse_ast *node = parse_redirection(&buf, &tok);
 		CHECK(node);
 		CHECK_EQ(node->type, ASTNODE_REDIRECTION);
+        CHECK_EQ(node->content.redirection->fd, 1);
+		CHECK_EQ(node->content.redirection->type, TOKTYPE_OUTPUT_APPENDING);
+		CHECK_EQ_STR(node->content.redirection->string_node
+					->content.string->text, "file");
+	}
+
+	TEST_SECTION("parse_redirection デスクリプタ付き >>");
+	{
+		t_parse_buffer	buf;
+		init_buf_with_string(&buf, "456>> file\n");
+		t_token	tok;
+
+		lex_get_token(&buf, &tok);
+
+		t_parse_ast *node = parse_redirection(&buf, &tok);
+		CHECK(node);
+		CHECK_EQ(node->type, ASTNODE_REDIRECTION);
+        CHECK_EQ(node->content.redirection->fd, 456);
 		CHECK_EQ(node->content.redirection->type, TOKTYPE_OUTPUT_APPENDING);
 		CHECK_EQ_STR(node->content.redirection->string_node
 					->content.string->text, "file");


### PR DESCRIPTION
closes #79 

t_parse_node_redirection 構造体に fd というメンバーを追加し、ここにファイルディスクリプタを書き込んでいます。
1 個のコマンドラインに複数のリダイレクトを指定することが可能になるので、t_command_invocation 内のリダイレクションのリストの構造などを適宜変更お願いします。
