### PR TITLE
バックスラッシュを使った文字のエスケープ

### DIFF
--- a/lexer.h
+++ b/lexer.h
@@ -21,9 +21,9 @@ typedef enum e_token_type
 
 typedef enum e_lexer_state
 {
-    LEXSTAT_NORMAL = 0xd101,
-    LEXSTAT_SINGLE_QUOTED,
-    LEXSTAT_DOUBLE_QUOTED,
+	LEXSTAT_NORMAL = 0xd101,
+	LEXSTAT_SINGLE_QUOTED,
+	LEXSTAT_DOUBLE_QUOTED,
 }	t_lexer_state;
 
 typedef struct s_token
@@ -44,5 +44,6 @@ int		lex_get_symbols(t_parse_buffer *buf, t_token *result, int ch);
 int		lex_get_quoted(t_parse_buffer *buf, t_token *result, int ch);
 int		lex_get_token(t_parse_buffer *buf, t_token *result);
 int		lex_check_redirection_with_fd(t_parse_buffer *buf, t_token *result);
+int		lex_escaped(t_parse_buffer *buf, t_token *result);
 
 #endif

--- a/lexer.h
+++ b/lexer.h
@@ -19,6 +19,13 @@ typedef enum e_token_type
 	TOKTYPE_SPACE,
 }	t_token_type;
 
+typedef enum e_lexer_state
+{
+    LEXSTAT_NORMAL = 0xd101,
+    LEXSTAT_SINGLE_QUOTED,
+    LEXSTAT_DOUBLE_QUOTED,
+}	t_lexer_state;
+
 typedef struct s_token
 {
 	char			text[TOKEN_BUFFER_SIZE];

--- a/lexer1.c
+++ b/lexer1.c
@@ -72,36 +72,27 @@ int	lex_get_quoted(t_parse_buffer *buf, t_token *result, int ch)
 int	lex_get_token(t_parse_buffer *buf, t_token *result)
 {
 	int	ch;
-	int	ret;
 
-	ret = 0;
+	if (buf->lex_stat == LEXSTAT_NORMAL)
+	{
+		ch = lex_getc(buf);
+		if (ch == EOF)
+			return (0);
+		if (lex_get_spaces(buf, result, ch)
+			|| lex_get_symbols(buf, result, ch)
+			|| lex_get_quoted(buf, result, ch))
+			return (1);
+		result->type = TOKTYPE_EXPANDABLE;
+		lex_ungetc(buf);
+		return (
+			lex_read_word(buf, result)
+			&& (lex_check_redirection_with_fd(buf, result) || 1));
+	}
 	if (buf->lex_stat == LEXSTAT_DOUBLE_QUOTED)
 	{
 		result->type = TOKTYPE_EXPANDABLE_QUOTED;
-		ret = lex_read_double_quoted(buf, result);
+		return (lex_read_double_quoted(buf, result));
 	}
-	else if (buf->lex_stat == LEXSTAT_SINGLE_QUOTED)
-	{
-		result->type = TOKTYPE_NON_EXPANDABLE;
-		ret = lex_read_single_quoted(buf, result);
-	}
-	else
-	{
-		ch = lex_getc(buf);
-		if (lex_get_spaces(buf, result, ch))
-			ret = 1;
-		else if (lex_get_symbols(buf, result, ch))
-			ret = 1;
-		else if (lex_get_quoted(buf, result, ch))
-			ret = 1;
-		else if (ch != EOF)
-		{
-			result->type = TOKTYPE_EXPANDABLE;
-			lex_ungetc(buf);
-			ret = lex_read_word(buf, result);
-			if (ret)
-				lex_check_redirection_with_fd(buf, result);
-		}
-	}
-	return (ret);
+	result->type = TOKTYPE_NON_EXPANDABLE;
+	return (lex_read_single_quoted(buf, result));
 }

--- a/lexer1.c
+++ b/lexer1.c
@@ -75,24 +75,33 @@ int	lex_get_token(t_parse_buffer *buf, t_token *result)
 	int	ret;
 
 	ret = 0;
-	ch = lex_getc(buf);
 	if (buf->lex_stat == LEXSTAT_DOUBLE_QUOTED)
-		ret = lex_read_double_quoted(buf, result);
-	else if (buf->lex_stat == LEXSTAT_SINGLE_QUOTED)
-		ret = lex_read_single_quoted(buf, result);
-	else if (lex_get_spaces(buf, result, ch))
-		ret = 1;
-	else if (lex_get_symbols(buf, result, ch))
-		ret = 1;
-	else if (lex_get_quoted(buf, result, ch))
-		ret = 1;
-	else if (ch != EOF)
 	{
-		result->type = TOKTYPE_EXPANDABLE;
-		lex_ungetc(buf);
-		ret = lex_read_word(buf, result);
-		if (ret)
-			lex_check_redirection_with_fd(buf, result);
+		result->type = TOKTYPE_EXPANDABLE_QUOTED;
+		ret = lex_read_double_quoted(buf, result);
+	}
+	else if (buf->lex_stat == LEXSTAT_SINGLE_QUOTED)
+	{
+		result->type = TOKTYPE_NON_EXPANDABLE;
+		ret = lex_read_single_quoted(buf, result);
+	}
+	else
+	{
+		ch = lex_getc(buf);
+		if (lex_get_spaces(buf, result, ch))
+			ret = 1;
+		else if (lex_get_symbols(buf, result, ch))
+			ret = 1;
+		else if (lex_get_quoted(buf, result, ch))
+			ret = 1;
+		else if (ch != EOF)
+		{
+			result->type = TOKTYPE_EXPANDABLE;
+			lex_ungetc(buf);
+			ret = lex_read_word(buf, result);
+			if (ret)
+				lex_check_redirection_with_fd(buf, result);
+		}
 	}
 	return (ret);
 }

--- a/lexer1.c
+++ b/lexer1.c
@@ -52,13 +52,17 @@ int	lex_get_symbols(t_parse_buffer *buf, t_token *result, int ch)
 
 int	lex_get_quoted(t_parse_buffer *buf, t_token *result, int ch)
 {
+	if (buf->lex_stat != LEXSTAT_NORMAL)
+		parse_die();
 	if (ch == '"')
 	{
+		buf->lex_stat = LEXSTAT_DOUBLE_QUOTED;
 		result->type = TOKTYPE_EXPANDABLE_QUOTED;
 		return (lex_read_double_quoted(buf, result));
 	}
 	else if (ch == '\'')
 	{
+		buf->lex_stat = LEXSTAT_SINGLE_QUOTED;
 		result->type = TOKTYPE_NON_EXPANDABLE;
 		return (lex_read_single_quoted(buf, result));
 	}
@@ -72,7 +76,11 @@ int	lex_get_token(t_parse_buffer *buf, t_token *result)
 
 	ret = 0;
 	ch = lex_getc(buf);
-	if (lex_get_spaces(buf, result, ch))
+	if (buf->lex_stat == LEXSTAT_DOUBLE_QUOTED)
+		ret = lex_read_double_quoted(buf, result);
+	else if (buf->lex_stat == LEXSTAT_SINGLE_QUOTED)
+		ret = lex_read_single_quoted(buf, result);
+	else if (lex_get_spaces(buf, result, ch))
 		ret = 1;
 	else if (lex_get_symbols(buf, result, ch))
 		ret = 1;

--- a/lexer2.c
+++ b/lexer2.c
@@ -62,6 +62,8 @@ int	lex_read_double_quoted(t_parse_buffer *buf, t_token *result)
 		ch = lex_getc(buf);
 		if (ch == '"')
 			buf->lex_stat = LEXSTAT_NORMAL;
+		if (ch == '\\')
+			lex_ungetc(buf);
 		if (ch == '\\' || ch == '"' || ch == '\n' || ch == EOF)
 			break ;
 		result->text[pos++] = ch;

--- a/lexer2.c
+++ b/lexer2.c
@@ -14,16 +14,8 @@ int	lex_read_word(t_parse_buffer *buf, t_token *result)
 	int	pos;
 	int	ch;
 
-	ch = lex_getc(buf);
-	if (ch == '\\')
-	{
-		ch = lex_getc(buf);
-		result->text[0] = ch;
-		result->length = 1;
-		result->type = TOKTYPE_NON_EXPANDABLE;
+	if (lex_escaped(buf, result))
 		return (1);
-	}
-	lex_ungetc(buf);
 	pos = 0;
 	while (1)
 	{
@@ -46,16 +38,8 @@ int	lex_read_double_quoted(t_parse_buffer *buf, t_token *result)
 	int	pos;
 	int	ch;
 
-	ch = lex_getc(buf);
-	if (ch == '\\')
-	{
-		ch = lex_getc(buf);
-		result->text[0] = ch;
-		result->length = 1;
-		result->type = TOKTYPE_NON_EXPANDABLE;
+	if (lex_escaped(buf, result))
 		return (1);
-	}
-	lex_ungetc(buf);
 	pos = 0;
 	while (1)
 	{

--- a/lexer2.c
+++ b/lexer2.c
@@ -14,13 +14,23 @@ int	lex_read_word(t_parse_buffer *buf, t_token *result)
 	int	pos;
 	int	ch;
 
+	ch = lex_getc(buf);
+	if (ch == '\\')
+	{
+		ch = lex_getc(buf);
+		result->text[0] = ch;
+		result->length = 1;
+		result->type = TOKTYPE_NON_EXPANDABLE;
+		return (1);
+	}
+	lex_ungetc(buf);
 	pos = 0;
 	while (1)
 	{
 		ch = lex_getc(buf);
 		if (ch == EOF)
 			break ;
-		if (lex_is_special_char(ch))
+		if (ch == '\\' || lex_is_special_char(ch))
 		{
 			lex_ungetc(buf);
 			break ;
@@ -36,11 +46,23 @@ int	lex_read_double_quoted(t_parse_buffer *buf, t_token *result)
 	int	pos;
 	int	ch;
 
+	ch = lex_getc(buf);
+	if (ch == '\\')
+	{
+		ch = lex_getc(buf);
+		result->text[0] = ch;
+		result->length = 1;
+		result->type = TOKTYPE_NON_EXPANDABLE;
+		return (1);
+	}
+	lex_ungetc(buf);
 	pos = 0;
 	while (1)
 	{
 		ch = lex_getc(buf);
-		if (ch == '"' || ch == '\n' || ch == EOF)
+		if (ch == '"')
+			buf->lex_stat = LEXSTAT_NORMAL;
+		if (ch == '\\' || ch == '"' || ch == '\n' || ch == EOF)
 			break ;
 		result->text[pos++] = ch;
 	}
@@ -57,6 +79,8 @@ int	lex_read_single_quoted(t_parse_buffer *buf, t_token *result)
 	while (1)
 	{
 		ch = lex_getc(buf);
+		if (ch == '\'')
+			buf->lex_stat = LEXSTAT_NORMAL;
 		if (ch == '\'' || ch == '\n' || ch == EOF)
 			break ;
 		result->text[pos++] = ch;

--- a/lexer3.c
+++ b/lexer3.c
@@ -14,6 +14,7 @@ int	lex_check_redirection_with_fd(t_parse_buffer *buf, t_token *result)
 			return (0);
 		i++;
 	}
+	result->text[i] = '\0';
 	ch = lex_getc(buf);
 	if (ch == '<' || ch == '>')
 	{
@@ -21,5 +22,7 @@ int	lex_check_redirection_with_fd(t_parse_buffer *buf, t_token *result)
 		lex_get_symbols(buf, result, ch);
 		result->length = fd;
 	}
+	else
+		lex_ungetc(buf);
 	return (1);
 }

--- a/lexer3.c
+++ b/lexer3.c
@@ -26,3 +26,20 @@ int	lex_check_redirection_with_fd(t_parse_buffer *buf, t_token *result)
 		lex_ungetc(buf);
 	return (1);
 }
+
+int	lex_escaped(t_parse_buffer *buf, t_token *result)
+{
+	char	ch;
+
+	ch = lex_getc(buf);
+	if (ch == '\\')
+	{
+		ch = lex_getc(buf);
+		result->text[0] = ch;
+		result->length = 1;
+		result->type = TOKTYPE_NON_EXPANDABLE;
+		return (1);
+	}
+	lex_ungetc(buf);
+	return (0);
+}

--- a/minishell.c
+++ b/minishell.c
@@ -17,6 +17,7 @@ void	init_buffer_with_string(t_parse_buffer *buf, char *str)
 	len = ft_strlen(str);
 	buf->cur_pos = 0;
 	buf->size = len;
+	buf->lex_stat = LEXSTAT_NORMAL;
 	ft_strlcpy(buf->buffer, str, len + 1);
 }
 

--- a/parse.h
+++ b/parse.h
@@ -7,9 +7,10 @@
 
 typedef struct s_parse_buffer
 {
-	char	buffer[PARSE_BUFFER_SIZE];
-	int		size;
-	int		cur_pos;
+	char			buffer[PARSE_BUFFER_SIZE];
+	int				size;
+	int				cur_pos;
+	t_lexer_state	lex_stat;
 }	t_parse_buffer;
 
 typedef enum e_parse_ast_type
@@ -106,6 +107,7 @@ t_parse_ast	*parse_delimiter(t_parse_buffer *buf, t_token *tok);
 t_parse_ast	*parse_sequential_commands(t_parse_buffer *buf, t_token *tok);
 t_parse_ast	*parse_command_line(t_parse_buffer *buf, t_token *tok);
 
+void		parse_die(void);
 void		parse_fatal_error(void);
 void		parse_skip_spaces(t_parse_buffer *buf, t_token *tok);
 

--- a/parse_utils.c
+++ b/parse_utils.c
@@ -1,6 +1,14 @@
 #include <stdlib.h>
 #include "parse.h"
 
+void	parse_die(void)
+{
+	int	*nullpo;
+
+	nullpo = NULL;
+	nullpo[0] = 0xD1E;
+}
+
 void	parse_skip_spaces(t_parse_buffer *buf, t_token *tok)
 {
 	while (1)

--- a/test/ast2cmdinvo_test.c
+++ b/test/ast2cmdinvo_test.c
@@ -8,6 +8,7 @@ void	init_buf_with_string(t_parse_buffer *buf, const char* str)
 	buf->cur_pos = 0;
 	strcpy(buf->buffer, str);
 	buf->size = strlen(str);
+	buf->lex_stat = LEXSTAT_NORMAL;
 }
 
 void check_strarr(const char **actual_strarr, const char **expected_strarr)

--- a/test/parse_test.c
+++ b/test/parse_test.c
@@ -41,7 +41,6 @@ void test_lexer()
 
 		lex_get_token(&buf, &tok);
 		CHECK_EQ(tok.type, TOKTYPE_INPUT_REDIRECTION);
-		printf("length: %d\n", tok.length);
 		CHECK_EQ(tok.length, 10);
 
 		lex_get_token(&buf, &tok);
@@ -179,6 +178,31 @@ void test_lexer()
 		CHECK_EQ(tok.type, TOKTYPE_NON_EXPANDABLE);
 		CHECK_EQ(tok.length, 2);
 		CHECK(!strncmp(tok.text, "wc", 2));
+	}
+
+	TEST_SECTION("lex_get_token クォートありエスケープあり");
+	{
+		t_parse_buffer	buf;
+		init_buf_with_string(&buf, "\"\\$ABC\" '\\abc'");
+		t_token	tok;
+
+		lex_get_token(&buf, &tok);
+		CHECK_EQ(tok.type, TOKTYPE_NON_EXPANDABLE);
+		CHECK_EQ(tok.length, 1);
+		CHECK(!strncmp(tok.text, "$", 1));
+
+		lex_get_token(&buf, &tok);
+		CHECK_EQ(tok.type, TOKTYPE_EXPANDABLE_QUOTED);
+		CHECK_EQ(tok.length, 3);
+		CHECK(!strncmp(tok.text, "ABC", 3));
+
+		lex_get_token(&buf, &tok);
+		CHECK_EQ(tok.type, TOKTYPE_SPACE);
+
+		lex_get_token(&buf, &tok);
+		CHECK_EQ(tok.type, TOKTYPE_NON_EXPANDABLE);
+		CHECK_EQ(tok.length, 4);
+		CHECK(!strncmp(tok.text, "\\abc", 4));
 	}
 
 	TEST_SECTION("lex_get_token のこり");

--- a/test/parse_test.c
+++ b/test/parse_test.c
@@ -205,6 +205,62 @@ void test_lexer()
 		CHECK(!strncmp(tok.text, "\\abc", 4));
 	}
 
+	TEST_SECTION("lex_get_token 数字だけのトークン");
+	{
+		t_parse_buffer	buf;
+		init_buf_with_string(&buf, "111 22 abcd ");
+		t_token	tok;
+
+		lex_get_token(&buf, &tok);
+		CHECK_EQ(tok.type, TOKTYPE_EXPANDABLE);
+		CHECK_EQ(tok.length, 3);
+		CHECK(!strncmp(tok.text, "111", 3));
+
+		lex_get_token(&buf, &tok);
+		CHECK_EQ(tok.type, TOKTYPE_SPACE);
+
+		lex_get_token(&buf, &tok);
+		CHECK_EQ(tok.type, TOKTYPE_EXPANDABLE);
+		CHECK_EQ(tok.length, 2);
+		CHECK(!strncmp(tok.text, "22", 3));
+
+		lex_get_token(&buf, &tok);
+		CHECK_EQ(tok.type, TOKTYPE_SPACE);
+
+		lex_get_token(&buf, &tok);
+		CHECK_EQ(tok.type, TOKTYPE_EXPANDABLE);
+		CHECK_EQ(tok.length, 4);
+		CHECK(!strncmp(tok.text, "abcd", 4));
+	}
+
+	TEST_SECTION("lex_get_token #88");
+	{
+		t_parse_buffer	buf;
+		init_buf_with_string(&buf, "chmod 000 dir ");
+		t_token	tok;
+
+		lex_get_token(&buf, &tok);
+		CHECK_EQ(tok.type, TOKTYPE_EXPANDABLE);
+		CHECK_EQ(tok.length, 5);
+		CHECK(!strncmp(tok.text, "chmod", 5));
+
+		lex_get_token(&buf, &tok);
+		CHECK_EQ(tok.type, TOKTYPE_SPACE);
+
+		lex_get_token(&buf, &tok);
+		CHECK_EQ(tok.type, TOKTYPE_EXPANDABLE);
+		CHECK_EQ(tok.length, 3);
+		CHECK(!strncmp(tok.text, "000", 3));
+
+		lex_get_token(&buf, &tok);
+		CHECK_EQ(tok.type, TOKTYPE_SPACE);
+
+		lex_get_token(&buf, &tok);
+		CHECK_EQ(tok.type, TOKTYPE_EXPANDABLE);
+		CHECK_EQ(tok.length, 3);
+		CHECK(!strncmp(tok.text, "dir", 3));
+	}
+
 	TEST_SECTION("lex_get_token のこり");
 	{
 		t_parse_buffer	buf;


### PR DESCRIPTION
closes #84 
closes #88 

クオートされていない部分とダブルクオートされている文字列中で、`\` の次の文字を TOKTYPE_NON_EXPANDABLE として扱います。

数字だけのトークンがあった場合の不具合もこれで直りました。