### PR TITLE
ASTからcmdinvoへの変換でエスケープに対応させる.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,8 @@ SRCS = cmd_cmd_invocation.c cmd_cmd_invocation2.c cmd_exec_command.c		\
 	cmd_status.c signal.c env_setter.c minishell_error_msg.c				\
 	builtin.c builtin_echo.c builtin_env.c builtin_exit.c					\
 	builtin_cd.c builtin_cd_path.c builtin_cd_chdir.c builtin_cd_cdpath.c	\
-	builtin_export.c builtin_pwd.c builtin_unset.c
+	builtin_export.c builtin_pwd.c builtin_unset.c							\
+	str_utils.c
 
 OBJS = $(SRCS:.c=.o)
 

--- a/builtin_cd_chdir.c
+++ b/builtin_cd_chdir.c
@@ -18,7 +18,7 @@ static char	*get_cd_abs_dest(char *dest, bool *is_canon_path)
 	char	*physical_path;
 	char	*canon_path;
 
-	if (dest[0] =='/')
+	if (dest[0] == '/')
 		physical_path = ft_strdup(dest);
 	else
 		physical_path = path_join(g_cwd, dest);

--- a/expand_env_var.c
+++ b/expand_env_var.c
@@ -110,6 +110,9 @@ static bool	join_str_or_env(char **result,
  * ex:
  *   in($ABC=" abc def "):  |"$ABC"'\'$ABC'|
  *   out:                   |" abc def "'\'$ABC'|
+ * ex:
+ *   in($ABC="hoge"):       |'$''$'"ABC"'\'"$ABC""$ABC"|
+ *   out:                   |'$''$'"ABC"'\'"hoge""hoge"|
  */
 char	*expand_env_var(char *str)
 {

--- a/expand_string_node.c
+++ b/expand_string_node.c
@@ -63,11 +63,11 @@ static char	**cmd_str2str_arr(t_cmd_str_node *str_node)
 	while (str_node)
 	{
 		// 前の文字列の右端と今回の文字列左端に空白が無ければくっつける
-		if (str_node->type == TOKTYPE_EXPANDABLE_QUOTED
-			|| str_node->type == TOKTYPE_NON_EXPANDABLE
-			&& last_idx >= 0
-			&& result[last_idx][ft_strlen(result[last_idx]) - 1] != ' '
-			&& str_node->text[0] != ' ')
+		if ((str_node->type == TOKTYPE_EXPANDABLE_QUOTED
+				|| str_node->type == TOKTYPE_NON_EXPANDABLE)
+			&& (last_idx >= 0
+				&& result[last_idx][ft_strlen(result[last_idx]) - 1] != ' '
+				&& str_node->text[0] != ' '))
 		{
 			char	*tmp = result[last_idx];
 			result[last_idx] = ft_strjoin(tmp, str_node->text);
@@ -89,7 +89,24 @@ char	**expand_string_node(t_parse_node_string *string_node)
 {
 	// string_nodeを中間表現構造体(テキストとタイプを持つ)の配列に変換する.
 	t_cmd_str_node *cmd_str = ast_str2cmd_str(string_node);
-	printf("%p\n", cmd_str);
+
+	t_cmd_str_node *tmp = cmd_str;
+	int i = 0;
+	while (tmp)
+	{
+		printf("%d:\n", i);
+		printf("\t|%s|\n", tmp->text);
+		if (tmp->type == TOKTYPE_EXPANDABLE)
+			printf("\tTOKTYPE_EXPANDABLE\n");
+		else if (tmp->type == TOKTYPE_EXPANDABLE_QUOTED)
+			printf("\tTOKTYPE_EXPANDABLE_QUOTED\n");
+		else if (tmp->type == TOKTYPE_NON_EXPANDABLE)
+			printf("\tTOKTYPE_NON_EXPANDABLE\n");
+		else
+			printf("\tUNKNOWN: %d\n", tmp->type);
+		i++;
+		tmp = tmp->next;
+	}
 	// 中間表現構造体を文字列配列にする.
 	char	**result = cmd_str2str_arr(cmd_str);
 

--- a/expand_string_node.c
+++ b/expand_string_node.c
@@ -56,7 +56,7 @@ static t_cmd_str_node	**ast_str2cmd_str(t_parse_node_string *str_node)
  *
  * Return: 更新された next_str
  */
-static char	*cmd_str_expandable2str_arr(char ***result,
+static char	*cmd_str_expandable2strarr(char ***result,
 	char *next_str, char *text)
 {
 	int		len;
@@ -101,7 +101,12 @@ static char	**cmd_str2str_arr(t_cmd_str_node **str_node)
 		if (str_node[i]->type != TOKTYPE_EXPANDABLE)
 			next_str = strjoin_and_free_first(next_str, str_node[i]->text);
 		else
-			cmd_str_expandable2str_arr(&result, &next_str, str_node[i]->text);
+			next_str = cmd_str_expandable2strarr(&result, next_str, str_node[i]->text);
+		if (!next_str)
+		{
+			free_ptrarr((void **)result);
+			return (NULL);
+		}
 		i++;
 	}
 	if (next_str && ft_strlen(next_str))
@@ -118,6 +123,8 @@ char	**expand_string_node(t_parse_node_string *string_node)
 	char			**result;
 
 	cmd_str = ast_str2cmd_str(string_node);
+	if (!cmd_str)
+		return (NULL);
 	result = cmd_str2str_arr(cmd_str);
 	i = 0;
 	while (cmd_str[i])

--- a/expand_string_node.c
+++ b/expand_string_node.c
@@ -75,7 +75,7 @@ static char	**cmd_str2str_arr(t_cmd_str_node **str_node)
 					start++;
 					end++;
 				}
-				if ((str_node[i]->text[end] == ' ' && start - end > 0) || !str_node[i]->text[end])
+				else if (str_node[i]->text[end] == ' ' && start - end)
 				{
 					char *tmp = next_str;
 					next_str = ft_strjoin(next_str, ft_substr(str_node[i]->text, start, end - start));
@@ -83,12 +83,21 @@ static char	**cmd_str2str_arr(t_cmd_str_node **str_node)
 
 					char	**tmparr;
 					tmparr = result;
+					printf("\t\tadd: |%s|\n", next_str);
 					result = (char **)ptrarr_add_ptr((void **)result, next_str);
 					free(tmparr);
 					next_str = ft_strdup("");
+					end++;
+					start = end;
 				}
 				else
 					end++;
+			}
+			if (start - end)
+			{
+				char *tmp = next_str;
+				next_str = ft_strjoin(next_str, ft_substr(str_node[i]->text, start, end - start));
+				free(tmp);
 			}
 		}
 		i++;
@@ -97,6 +106,7 @@ static char	**cmd_str2str_arr(t_cmd_str_node **str_node)
 	{
 		char	**tmparr;
 		tmparr = result;
+					printf("\t\tadd: |%s|\n", next_str);
 		result = (char **)ptrarr_add_ptr((void **)result, next_str);
 		free(tmparr);
 	}
@@ -111,6 +121,7 @@ char	**expand_string_node(t_parse_node_string *string_node)
 	t_cmd_str_node **cmd_str = ast_str2cmd_str(string_node);
 
 	int i = 0;
+	printf("cmd_str:\n");
 	while (cmd_str[i])
 	{
 		printf("%d:\n", i);
@@ -125,8 +136,17 @@ char	**expand_string_node(t_parse_node_string *string_node)
 			printf("\tUNKNOWN: %d\n", cmd_str[i]->type);
 		i++;
 	}
+
 	// 中間表現構造体を文字列配列にする.
 	char	**result = cmd_str2str_arr(cmd_str);
+
+	i = 0;
+	printf("result:\n");
+	while (result[i])
+	{
+		printf("result[%d]: |%s|\n", i, result[i]);
+		i++;
+	}
 
 	i = 0;
 	while (cmd_str[i])

--- a/expand_string_node.c
+++ b/expand_string_node.c
@@ -1,11 +1,6 @@
 #include "minishell.h"
 #include "utils.h"
 
-typedef struct	s_cmd_str_node {
-	char					*text;
-	t_token_type			type;
-}				t_cmd_str_node;
-
 static bool	cmd_str_node_add_back(t_cmd_str_node ***str_node_arr, char *text, t_token_type tok_type)
 {
 	t_cmd_str_node	*new_node;

--- a/expand_string_node.c
+++ b/expand_string_node.c
@@ -102,22 +102,3 @@ char	**expand_string_node(t_parse_node_string *string_node)
 	}
 	return (result);
 }
-
-// /*
-//  * 一度文字列を全て展開した上でexpanded_strarrを生成する
-//  */
-// char	**expand_string_node(t_parse_node_string *string_node)
-// {
-// 	char	*restored_str;
-// 	char	*expanded_str;
-// 	char	**splitted_expanded_str;
-// 
-// 	restored_str = string_node2string(string_node);
-// 	printf("restored_str: |%s|\n", restored_str);
-// 	expanded_str = expand_env_var(restored_str);
-// 	free(restored_str);
-// 	printf("expanded_str: |%s|\n", expanded_str);
-// 	splitted_expanded_str = split_expanded_str(expanded_str);
-// 	free(expanded_str);
-// 	return (splitted_expanded_str);
-// }

--- a/expand_string_node.c
+++ b/expand_string_node.c
@@ -157,5 +157,6 @@ char	**expand_string_node(t_parse_node_string *string_node)
 		free(cmd_str[i]);
 		i++;
 	}
+	free(cmd_str);
 	return (result);
 }

--- a/expand_string_node.c
+++ b/expand_string_node.c
@@ -51,7 +51,7 @@ static t_cmd_str_node	**ast_str2cmd_str(t_parse_node_string *str_node)
  * 渡された next_str を更新する際はは内部でfreeする.
  *
  * result: 文字列配列変数へのポインタ
- *   (Normのためにvoidポインタになってる)
+ *   (Normのためにvoidポインタにしている)
  * next_str: 次resultに追加される文字列を指すポインタ
  * text: str_node->text
  *

--- a/expand_string_node.c
+++ b/expand_string_node.c
@@ -51,12 +51,13 @@ static t_cmd_str_node	**ast_str2cmd_str(t_parse_node_string *str_node)
  * 渡された next_str を更新する際はは内部でfreeする.
  *
  * result: 文字列配列変数へのポインタ
+ *   (Normのためにvoidポインタになってる)
  * next_str: 次resultに追加される文字列を指すポインタ
  * text: str_node->text
  *
  * Return: 更新された next_str
  */
-static char	*expandable_node2strarr(char ***result,
+static char	*expandable_node2strarr(void ***result,
 	char *next_str, char *text)
 {
 	int		len;
@@ -70,8 +71,7 @@ static char	*expandable_node2strarr(char ***result,
 		{
 			next_str = strjoin_nullable_and_free_both(
 					next_str, ft_substr(text, 0, len));
-			*result = (char **)ptrarr_add_ptr_and_free((void **)*result,
-					next_str);
+			*result = ptrarr_add_ptr_and_free(*result, next_str);
 			next_str = NULL;
 			if (!*result)
 				return (NULL);
@@ -90,7 +90,7 @@ static char	*expandable_node2strarr(char ***result,
 /* 中間表現構造体を文字列配列にする. */
 static char	**cmd_str2str_arr(t_cmd_str_node **str_node)
 {
-	char	**result;
+	void	**result;
 	char	*next_str;
 	int		i;
 
@@ -112,8 +112,8 @@ static char	**cmd_str2str_arr(t_cmd_str_node **str_node)
 		i++;
 	}
 	if (next_str)
-		result = (char **)ptrarr_add_ptr_and_free((void **)result, next_str);
-	return (result);
+		result = ptrarr_add_ptr_and_free(result, next_str);
+	return ((char **)result);
 }
 
 /* t_parse_node_string を文字列配列に変換して返す */

--- a/expand_string_node.c
+++ b/expand_string_node.c
@@ -56,7 +56,7 @@ static t_cmd_str_node	**ast_str2cmd_str(t_parse_node_string *str_node)
  *
  * Return: 更新された next_str
  */
-static char	*cmd_str_expandable2strarr(char ***result,
+static char	*expandable_node2strarr(char ***result,
 	char *next_str, char *text)
 {
 	int		len;
@@ -96,19 +96,17 @@ static char	**cmd_str2str_arr(t_cmd_str_node **str_node)
 	i = 0;
 	result = NULL;
 	next_str = ft_strdup("");
-	while (str_node[i])
+	while (str_node[i] && next_str)
 	{
 		if (str_node[i]->type != TOKTYPE_EXPANDABLE)
 			next_str = strjoin_and_free_first(next_str, str_node[i]->text);
 		else
-			next_str = cmd_str_expandable2strarr(&result, next_str, str_node[i]->text);
-		if (!next_str)
-		{
-			free_ptrarr((void **)result);
-			return (NULL);
-		}
+			next_str = expandable_node2strarr(&result, next_str,
+					str_node[i]->text);
 		i++;
 	}
+	if (!next_str)
+		free_ptrarr_and_assign_null((void ***)&result);
 	if (next_str && ft_strlen(next_str))
 		result = (char **)ptrarr_add_ptr_and_free((void **)result, next_str);
 	else

--- a/expand_string_node.c
+++ b/expand_string_node.c
@@ -10,8 +10,10 @@ char	**expand_string_node(t_parse_node_string *string_node)
 	char	**splitted_expanded_str;
 
 	restored_str = string_node2string(string_node);
+	printf("restored_str: |%s|\n", restored_str);
 	expanded_str = expand_env_var(restored_str);
 	free(restored_str);
+	printf("expanded_str: |%s|\n", expanded_str);
 	splitted_expanded_str = split_expanded_str(expanded_str);
 	free(expanded_str);
 	return (splitted_expanded_str);

--- a/expand_string_node.c
+++ b/expand_string_node.c
@@ -68,13 +68,16 @@ static char	*expandable_node2strarr(char ***result,
 			text++;
 		else if (text[len] == ' ' && len)
 		{
-			next_str = strjoin_and_free_both(next_str,
-					ft_substr(text, 0, len));
+			if (next_str)
+				next_str = strjoin_and_free_both(next_str,
+						ft_substr(text, 0, len));
+			else
+				next_str = ft_substr(text, 0, len);
 			*result = (char **)ptrarr_add_ptr_and_free((void **)*result,
 					next_str);
-			next_str = ft_strdup("");
-			if (!*result || !next_str)
-				return (false);
+			next_str = NULL;
+			if (!*result)
+				return (NULL);
 			text += len + 1;
 			len = 0;
 		}
@@ -82,7 +85,12 @@ static char	*expandable_node2strarr(char ***result,
 			len++;
 	}
 	if (len)
-		next_str = strjoin_and_free_both(next_str, ft_substr(text, 0, len));
+	{
+		if (next_str)
+			next_str = strjoin_and_free_both(next_str, ft_substr(text, 0, len));
+		else
+			next_str = ft_substr(text, 0, len);
+	}
 	return (next_str);
 }
 
@@ -95,22 +103,23 @@ static char	**cmd_str2str_arr(t_cmd_str_node **str_node)
 
 	i = 0;
 	result = NULL;
-	next_str = ft_strdup("");
-	while (str_node[i] && next_str)
+	next_str = NULL;
+	while (str_node[i])
 	{
 		if (str_node[i]->type != TOKTYPE_EXPANDABLE)
-			next_str = strjoin_and_free_first(next_str, str_node[i]->text);
+		{
+			if (next_str)
+				next_str = strjoin_and_free_first(next_str, str_node[i]->text);
+			else
+				next_str = ft_strdup(str_node[i]->text);
+		}
 		else
 			next_str = expandable_node2strarr(&result, next_str,
 					str_node[i]->text);
 		i++;
 	}
-	if (!next_str)
-		free_ptrarr_and_assign_null((void ***)&result);
-	if (next_str && ft_strlen(next_str))
+	if (next_str)
 		result = (char **)ptrarr_add_ptr_and_free((void **)result, next_str);
-	else
-		free(next_str);
 	return (result);
 }
 

--- a/expand_string_node.c
+++ b/expand_string_node.c
@@ -1,20 +1,123 @@
 #include "minishell.h"
 
-/*
- * 一度文字列を全て展開した上でexpanded_strarrを生成する
+typedef struct	s_cmd_str_node {
+	char					*text;
+	t_token_type			type;
+	struct s_cmd_str_node	*next;
+}				t_cmd_str_node;
+
+static t_cmd_str_node	*cmd_str_node_add_back(t_cmd_str_node **str_node, char *text, t_token_type tok_type)
+{
+	t_cmd_str_node	*current_node;
+	t_cmd_str_node	*new_node;
+
+	new_node = ft_calloc(1, sizeof(t_cmd_str_node));
+	if (!new_node)
+		return (NULL);
+	new_node->text = text;
+	new_node->type = tok_type;
+	if (!*str_node)
+	{
+		*str_node = new_node;
+		return (new_node);
+	}
+	current_node = *str_node;
+	while (current_node->next)
+		current_node = current_node->next;
+	current_node->next = new_node;
+	return (new_node);
+}
+
+/* ast_str_node を cmd_str_node に変換する(環境変数は展開する).
  */
+static t_cmd_str_node	*ast_str2cmd_str(t_parse_node_string *str_node)
+{
+	t_cmd_str_node	*result;
+	char			*expanded_str;
+
+	result = NULL;
+	while (str_node)
+	{
+		if (str_node->type == TOKTYPE_NON_EXPANDABLE)
+			expanded_str = ft_strdup(str_node->text);
+		else
+			expanded_str = expand_env_var(str_node->text);
+		if (!cmd_str_node_add_back(&result, expanded_str, str_node->type))
+				return (NULL);
+		if (str_node->next)
+			str_node = str_node->next->content.string;
+		else
+			str_node = NULL;
+	}
+	return (result);
+}
+
+/* 中間表現構造体を文字列配列にする. */
+static char	**cmd_str2str_arr(t_cmd_str_node *str_node)
+{
+	char	**result;
+	int		last_idx;
+
+	last_idx = -1;  // resultの最後の文字列への添字
+	result = NULL;
+	while (str_node)
+	{
+		// 前の文字列の右端と今回の文字列左端に空白が無ければくっつける
+		if (str_node->type == TOKTYPE_EXPANDABLE_QUOTED
+			|| str_node->type == TOKTYPE_NON_EXPANDABLE
+			&& last_idx >= 0
+			&& result[last_idx][ft_strlen(result[last_idx]) - 1] != ' '
+			&& str_node->text[0] != ' ')
+		{
+			char	*tmp = result[last_idx];
+			result[last_idx] = ft_strjoin(tmp, str_node->text);
+			free(tmp);
+		}
+		else
+		{
+			char	**tmp = result;
+			result = (char **)ptrarr_add_ptr((void **)result, ft_strdup(str_node->text));
+			free(tmp);
+			last_idx = ptrarr_len((void **)result) - 1;
+		}
+		str_node = str_node->next;
+	}
+	return (result);
+}
+
 char	**expand_string_node(t_parse_node_string *string_node)
 {
-	char	*restored_str;
-	char	*expanded_str;
-	char	**splitted_expanded_str;
+	// string_nodeを中間表現構造体(テキストとタイプを持つ)の配列に変換する.
+	t_cmd_str_node *cmd_str = ast_str2cmd_str(string_node);
+	printf("%p\n", cmd_str);
+	// 中間表現構造体を文字列配列にする.
+	char	**result = cmd_str2str_arr(cmd_str);
 
-	restored_str = string_node2string(string_node);
-	printf("restored_str: |%s|\n", restored_str);
-	expanded_str = expand_env_var(restored_str);
-	free(restored_str);
-	printf("expanded_str: |%s|\n", expanded_str);
-	splitted_expanded_str = split_expanded_str(expanded_str);
-	free(expanded_str);
-	return (splitted_expanded_str);
+	while (cmd_str)
+	{
+		free(cmd_str->text);
+		t_cmd_str_node *tmp = cmd_str;
+		cmd_str = cmd_str->next;
+		free(tmp);
+	}
+	return (result);
 }
+
+// /*
+//  * 一度文字列を全て展開した上でexpanded_strarrを生成する
+//  */
+// char	**expand_string_node(t_parse_node_string *string_node)
+// {
+// 	char	*restored_str;
+// 	char	*expanded_str;
+// 	char	**splitted_expanded_str;
+// 
+// 	restored_str = string_node2string(string_node);
+// 	printf("restored_str: |%s|\n", restored_str);
+// 	expanded_str = expand_env_var(restored_str);
+// 	free(restored_str);
+// 	printf("expanded_str: |%s|\n", expanded_str);
+// 	splitted_expanded_str = split_expanded_str(expanded_str);
+// 	free(expanded_str);
+// 	return (splitted_expanded_str);
+// }

--- a/expand_string_node.c
+++ b/expand_string_node.c
@@ -57,8 +57,10 @@ static void	cmd_str_expandable2str_arr(char ***result,
 			str++;
 		else if (str[len] == ' ' && len)
 		{
-			*next_str = strjoin_and_free_both(*next_str, ft_substr(str, 0, len));
-			*result = (char **)ptrarr_add_ptr_and_free((void **)*result, *next_str);
+			*next_str = strjoin_and_free_both(*next_str,
+					ft_substr(str, 0, len));
+			*result = (char **)ptrarr_add_ptr_and_free((void **)*result,
+					*next_str);
 			*next_str = ft_strdup("");
 			str += len + 1;
 			len = 0;
@@ -74,7 +76,7 @@ static void	cmd_str_expandable2str_arr(char ***result,
 static char	**cmd_str2str_arr(t_cmd_str_node **str_node)
 {
 	char	**result;
-	char	*next_str;  // 次resultに追加される文字列
+	char	*next_str;
 	int		i;
 	char	**tmparr;
 
@@ -102,37 +104,12 @@ static char	**cmd_str2str_arr(t_cmd_str_node **str_node)
 
 char	**expand_string_node(t_parse_node_string *string_node)
 {
-	// string_nodeを中間表現構造体(テキストとタイプを持つ)の配列に変換する.
-	t_cmd_str_node **cmd_str = ast_str2cmd_str(string_node);
+	t_cmd_str_node	**cmd_str;
+	int				i;
+	char			**result;
 
-	int i = 0;
-	printf("cmd_str:\n");
-	while (cmd_str[i])
-	{
-		printf("%d:\n", i);
-		printf("\t|%s|\n", cmd_str[i]->text);
-		if (cmd_str[i]->type == TOKTYPE_EXPANDABLE)
-			printf("\tTOKTYPE_EXPANDABLE\n");
-		else if (cmd_str[i]->type == TOKTYPE_EXPANDABLE_QUOTED)
-			printf("\tTOKTYPE_EXPANDABLE_QUOTED\n");
-		else if (cmd_str[i]->type == TOKTYPE_NON_EXPANDABLE)
-			printf("\tTOKTYPE_NON_EXPANDABLE\n");
-		else
-			printf("\tUNKNOWN: %d\n", cmd_str[i]->type);
-		i++;
-	}
-
-	// 中間表現構造体を文字列配列にする.
-	char	**result = cmd_str2str_arr(cmd_str);
-
-	i = 0;
-	printf("result:\n");
-	while (result && result[i])
-	{
-		printf("result[%d]: |%s|\n", i, result[i]);
-		i++;
-	}
-
+	cmd_str = ast_str2cmd_str(string_node);
+	result = cmd_str2str_arr(cmd_str);
 	i = 0;
 	while (cmd_str[i])
 	{

--- a/expand_string_node.c
+++ b/expand_string_node.c
@@ -142,7 +142,7 @@ char	**expand_string_node(t_parse_node_string *string_node)
 
 	i = 0;
 	printf("result:\n");
-	while (result[i])
+	while (result && result[i])
 	{
 		printf("result[%d]: |%s|\n", i, result[i]);
 		i++;

--- a/expand_string_node.c
+++ b/expand_string_node.c
@@ -47,32 +47,30 @@ static t_cmd_str_node	**ast_str2cmd_str(t_parse_node_string *str_node)
 }
 
 static void	cmd_str_expandable2str_arr(char ***result,
-	char **next_str, t_cmd_str_node *str_node)
+	char **next_str, char *text)
 {
 	int		len;
-	char	*str;
 
 	len = 0;
-	str = str_node->text;
-	while (str[len])
+	while (text[len])
 	{
-		if (str[len] == ' ' && len == 0)
-			str++;
-		else if (str[len] == ' ' && len)
+		if (text[len] == ' ' && len == 0)
+			text++;
+		else if (text[len] == ' ' && len)
 		{
 			*next_str = strjoin_and_free_both(*next_str,
-					ft_substr(str, 0, len));
+					ft_substr(text, 0, len));
 			*result = (char **)ptrarr_add_ptr_and_free((void **)*result,
 					*next_str);
 			*next_str = ft_strdup("");
-			str += len + 1;
+			text += len + 1;
 			len = 0;
 		}
 		else
 			len++;
 	}
 	if (len)
-		*next_str = strjoin_and_free_both(*next_str, ft_substr(str, 0, len));
+		*next_str = strjoin_and_free_both(*next_str, ft_substr(text, 0, len));
 }
 
 /* 中間表現構造体を文字列配列にする. */
@@ -91,7 +89,7 @@ static char	**cmd_str2str_arr(t_cmd_str_node **str_node)
 		if (str_node[i]->type != TOKTYPE_EXPANDABLE)
 			next_str = strjoin_and_free_first(next_str, str_node[i]->text);
 		else
-			cmd_str_expandable2str_arr(&result, &next_str, str_node[i]);
+			cmd_str_expandable2str_arr(&result, &next_str, str_node[i]->text);
 		i++;
 	}
 	if (next_str && ft_strlen(next_str))

--- a/expand_string_node.c
+++ b/expand_string_node.c
@@ -16,6 +16,8 @@ static bool	cmd_str_node_add_back(t_cmd_str_node ***str_node_arr,
 	*str_node_arr = (t_cmd_str_node **)ptrarr_add_ptr(
 			(void **)*str_node_arr, new_node);
 	free(tmp);
+	if (!*str_node_arr)
+		return (false);
 	return (true);
 }
 
@@ -33,7 +35,8 @@ static t_cmd_str_node	**ast_str2cmd_str(t_parse_node_string *str_node)
 			expanded_str = ft_strdup(str_node->text);
 		else
 			expanded_str = expand_env_var(str_node->text);
-		if (!cmd_str_node_add_back(&result, expanded_str, str_node->type))
+		if (!expanded_str
+			|| !cmd_str_node_add_back(&result, expanded_str, str_node->type))
 			return (NULL);
 		if (str_node->next)
 			str_node = str_node->next->content.string;

--- a/expand_string_node.c
+++ b/expand_string_node.c
@@ -69,7 +69,7 @@ static char	*expandable_node2strarr(char ***result,
 		else if (text[len] == ' ' && len)
 		{
 			next_str = strjoin_nullable_and_free_both(
-				next_str, ft_substr(text, 0, len));
+					next_str, ft_substr(text, 0, len));
 			*result = (char **)ptrarr_add_ptr_and_free((void **)*result,
 					next_str);
 			next_str = NULL;
@@ -83,7 +83,7 @@ static char	*expandable_node2strarr(char ***result,
 	}
 	if (len)
 		next_str = strjoin_nullable_and_free_both(
-			next_str, ft_substr(text, 0, len));
+				next_str, ft_substr(text, 0, len));
 	return (next_str);
 }
 
@@ -116,6 +116,7 @@ static char	**cmd_str2str_arr(t_cmd_str_node **str_node)
 	return (result);
 }
 
+/* t_parse_node_string を文字列配列に変換して返す */
 char	**expand_string_node(t_parse_node_string *string_node)
 {
 	t_cmd_str_node	**cmd_str;

--- a/expand_string_node.c
+++ b/expand_string_node.c
@@ -46,9 +46,18 @@ static t_cmd_str_node	**ast_str2cmd_str(t_parse_node_string *str_node)
 	return ((t_cmd_str_node **)result);
 }
 
-/* TOKTYPE_EXPANDABLEを処理する */
-static bool	cmd_str_expandable2str_arr(char ***result,
-	char **next_str, char *text)
+/* TOKTYPE_EXPANDABLEを処理する
+ *
+ * 渡された next_str を更新する際はは内部でfreeする.
+ *
+ * result: 文字列配列変数へのポインタ
+ * next_str: 次resultに追加される文字列を指すポインタ
+ * text: str_node->text
+ *
+ * Return: 更新された next_str
+ */
+static char	*cmd_str_expandable2str_arr(char ***result,
+	char *next_str, char *text)
 {
 	int		len;
 
@@ -59,12 +68,12 @@ static bool	cmd_str_expandable2str_arr(char ***result,
 			text++;
 		else if (text[len] == ' ' && len)
 		{
-			*next_str = strjoin_and_free_both(*next_str,
+			next_str = strjoin_and_free_both(next_str,
 					ft_substr(text, 0, len));
 			*result = (char **)ptrarr_add_ptr_and_free((void **)*result,
-					*next_str);
-			*next_str = ft_strdup("");
-			if (!*result || !*next_str)
+					next_str);
+			next_str = ft_strdup("");
+			if (!*result || !next_str)
 				return (false);
 			text += len + 1;
 			len = 0;
@@ -73,8 +82,8 @@ static bool	cmd_str_expandable2str_arr(char ***result,
 			len++;
 	}
 	if (len)
-		*next_str = strjoin_and_free_both(*next_str, ft_substr(text, 0, len));
-	return (!!*next_str);
+		next_str = strjoin_and_free_both(next_str, ft_substr(text, 0, len));
+	return (next_str);
 }
 
 /* 中間表現構造体を文字列配列にする. */

--- a/expand_string_node.c
+++ b/expand_string_node.c
@@ -1,61 +1,123 @@
 #include "minishell.h"
 
-/* 前の文字列の右端と今回の文字列左端に空白が無ければくっつける */
-static bool argv_add_arg(char ***argv, char *arg)
-{
-	char	argv_len;
+typedef struct	s_cmd_str_node {
+	char					*text;
+	t_token_type			type;
+	struct s_cmd_str_node	*next;
+}				t_cmd_str_node;
 
-	if (!*argv)
+static t_cmd_str_node	*cmd_str_node_add_back(t_cmd_str_node **str_node, char *text, t_token_type tok_type)
+{
+	t_cmd_str_node	*current_node;
+	t_cmd_str_node	*new_node;
+
+	new_node = ft_calloc(1, sizeof(t_cmd_str_node));
+	if (!new_node)
+		return (NULL);
+	new_node->text = text;
+	new_node->type = tok_type;
+	if (!*str_node)
 	{
-		*argv = (char **)ptrarr_add_ptr((void **)argv, arg);
-		return (!!*argv);
+		*str_node = new_node;
+		return (new_node);
 	}
-	argv_len = ptrarr_len((void **)(*argv));
-	if ((*argv)[argv_len - 1][ft_strlen((*argv)[argv_len - 1]) - 1] != ' '
-		&& arg[ft_strlen(arg) - 1] != ' ')
-	{
-		char	*tmp = (*argv)[argv_len - 1];
-		(*argv)[argv_len - 1] = ft_strjoin((*argv)[argv_len - 1], arg);
-		free(tmp);
-	}
-	else
-	{
-		char **tmp = (*argv);
-		(*argv) = (char **)ptrarr_add_ptr((void **)(*argv), arg);
-		free(tmp);
-	}
-	return (!!(*argv));
+	current_node = *str_node;
+	while (current_node->next)
+		current_node = current_node->next;
+	current_node->next = new_node;
+	return (new_node);
 }
 
-char	**expand_string_node(t_parse_node_string *string_node)
+/* ast_str_node を cmd_str_node に変換する(環境変数は展開する).
+ */
+static t_cmd_str_node	*ast_str2cmd_str(t_parse_node_string *str_node)
 {
-	char			**result;
+	t_cmd_str_node	*result;
 	char			*expanded_str;
 
 	result = NULL;
-	while (string_node)
+	while (str_node)
 	{
-		if (string_node->type == TOKTYPE_NON_EXPANDABLE)
-			expanded_str = ft_strdup(string_node->text);
+		if (str_node->type == TOKTYPE_NON_EXPANDABLE)
+			expanded_str = ft_strdup(str_node->text);
 		else
-			expanded_str = expand_env_var(string_node->text);
-		// EXPANDABLE_QUOTED なら ft_split() して追加する
-		if (string_node->type == TOKTYPE_EXPANDABLE)
-		{
-			char	**tmp = ft_split(expanded_str, ' ');
-			free(expanded_str);
-			int i = 0;
-			while (tmp[i])
-				argv_add_arg(&result, tmp[i++]);
-			free(tmp);
-		}
+			expanded_str = expand_env_var(str_node->text);
+		if (!cmd_str_node_add_back(&result, expanded_str, str_node->type))
+				return (NULL);
+		if (str_node->next)
+			str_node = str_node->next->content.string;
 		else
-			argv_add_arg(&result, expanded_str);
-		if (string_node->next)
-			string_node = string_node->next->content.string;
-		else
-			string_node = NULL;
+			str_node = NULL;
 	}
 	return (result);
 }
 
+/* 中間表現構造体を文字列配列にする. */
+static char	**cmd_str2str_arr(t_cmd_str_node *str_node)
+{
+	char	**result;
+	int		last_idx;
+
+	last_idx = -1;  // resultの最後の文字列への添字
+	result = NULL;
+	while (str_node)
+	{
+		// 前の文字列の右端と今回の文字列左端に空白が無ければくっつける
+		if (str_node->type == TOKTYPE_EXPANDABLE_QUOTED
+			|| str_node->type == TOKTYPE_NON_EXPANDABLE
+			&& last_idx >= 0
+			&& result[last_idx][ft_strlen(result[last_idx]) - 1] != ' '
+			&& str_node->text[0] != ' ')
+		{
+			char	*tmp = result[last_idx];
+			result[last_idx] = ft_strjoin(tmp, str_node->text);
+			free(tmp);
+		}
+		else
+		{
+			char	**tmp = result;
+			result = (char **)ptrarr_add_ptr((void **)result, ft_strdup(str_node->text));
+			free(tmp);
+			last_idx = ptrarr_len((void **)result) - 1;
+		}
+		str_node = str_node->next;
+	}
+	return (result);
+}
+
+char	**expand_string_node(t_parse_node_string *string_node)
+{
+	// string_nodeを中間表現構造体(テキストとタイプを持つ)の配列に変換する.
+	t_cmd_str_node *cmd_str = ast_str2cmd_str(string_node);
+	printf("%p\n", cmd_str);
+	// 中間表現構造体を文字列配列にする.
+	char	**result = cmd_str2str_arr(cmd_str);
+
+	while (cmd_str)
+	{
+		free(cmd_str->text);
+		t_cmd_str_node *tmp = cmd_str;
+		cmd_str = cmd_str->next;
+		free(tmp);
+	}
+	return (result);
+}
+
+// /*
+//  * 一度文字列を全て展開した上でexpanded_strarrを生成する
+//  */
+// char	**expand_string_node(t_parse_node_string *string_node)
+// {
+// 	char	*restored_str;
+// 	char	*expanded_str;
+// 	char	**splitted_expanded_str;
+// 
+// 	restored_str = string_node2string(string_node);
+// 	printf("restored_str: |%s|\n", restored_str);
+// 	expanded_str = expand_env_var(restored_str);
+// 	free(restored_str);
+// 	printf("expanded_str: |%s|\n", expanded_str);
+// 	splitted_expanded_str = split_expanded_str(expanded_str);
+// 	free(expanded_str);
+// 	return (splitted_expanded_str);
+// }

--- a/expand_string_node.c
+++ b/expand_string_node.c
@@ -3,36 +3,29 @@
 typedef struct	s_cmd_str_node {
 	char					*text;
 	t_token_type			type;
-	struct s_cmd_str_node	*next;
 }				t_cmd_str_node;
 
-static t_cmd_str_node	*cmd_str_node_add_back(t_cmd_str_node **str_node, char *text, t_token_type tok_type)
+static bool	cmd_str_node_add_back(t_cmd_str_node ***str_node_arr, char *text, t_token_type tok_type)
 {
-	t_cmd_str_node	*current_node;
 	t_cmd_str_node	*new_node;
+	t_cmd_str_node	**tmp;
 
-	new_node = ft_calloc(1, sizeof(t_cmd_str_node));
+	new_node = malloc(sizeof(t_cmd_str_node));
 	if (!new_node)
-		return (NULL);
+		return (false);
 	new_node->text = text;
 	new_node->type = tok_type;
-	if (!*str_node)
-	{
-		*str_node = new_node;
-		return (new_node);
-	}
-	current_node = *str_node;
-	while (current_node->next)
-		current_node = current_node->next;
-	current_node->next = new_node;
-	return (new_node);
+	tmp = *str_node_arr;
+	*str_node_arr = (t_cmd_str_node **)ptrarr_add_ptr((void **)*str_node_arr, new_node);
+	free(tmp);
+	return (true);
 }
 
 /* ast_str_node を cmd_str_node に変換する(環境変数は展開する).
  */
-static t_cmd_str_node	*ast_str2cmd_str(t_parse_node_string *str_node)
+static t_cmd_str_node	**ast_str2cmd_str(t_parse_node_string *str_node)
 {
-	t_cmd_str_node	*result;
+	t_cmd_str_node	**result;
 	char			*expanded_str;
 
 	result = NULL;
@@ -43,44 +36,32 @@ static t_cmd_str_node	*ast_str2cmd_str(t_parse_node_string *str_node)
 		else
 			expanded_str = expand_env_var(str_node->text);
 		if (!cmd_str_node_add_back(&result, expanded_str, str_node->type))
-				return (NULL);
+			return (NULL);
 		if (str_node->next)
 			str_node = str_node->next->content.string;
 		else
 			str_node = NULL;
 	}
-	return (result);
+	return ((t_cmd_str_node **)result);
 }
 
 /* 中間表現構造体を文字列配列にする. */
-static char	**cmd_str2str_arr(t_cmd_str_node *str_node)
+static char	**cmd_str2str_arr(t_cmd_str_node **str_node)
 {
 	char	**result;
-	int		last_idx;
+	int		i;
 
-	last_idx = -1;  // resultの最後の文字列への添字
+	i = 0;
 	result = NULL;
-	while (str_node)
+	while (str_node[i])
 	{
 		// 前の文字列の右端と今回の文字列左端に空白が無ければくっつける
-		if ((str_node->type == TOKTYPE_EXPANDABLE_QUOTED
-				|| str_node->type == TOKTYPE_NON_EXPANDABLE)
-			&& (last_idx >= 0
-				&& result[last_idx][ft_strlen(result[last_idx]) - 1] != ' '
-				&& str_node->text[0] != ' '))
+		int j = 0;
+		while (str_node[i]->text[j])
 		{
-			char	*tmp = result[last_idx];
-			result[last_idx] = ft_strjoin(tmp, str_node->text);
-			free(tmp);
+			
 		}
-		else
-		{
-			char	**tmp = result;
-			result = (char **)ptrarr_add_ptr((void **)result, ft_strdup(str_node->text));
-			free(tmp);
-			last_idx = ptrarr_len((void **)result) - 1;
-		}
-		str_node = str_node->next;
+		i++;
 	}
 	return (result);
 }
@@ -88,34 +69,32 @@ static char	**cmd_str2str_arr(t_cmd_str_node *str_node)
 char	**expand_string_node(t_parse_node_string *string_node)
 {
 	// string_nodeを中間表現構造体(テキストとタイプを持つ)の配列に変換する.
-	t_cmd_str_node *cmd_str = ast_str2cmd_str(string_node);
+	t_cmd_str_node **cmd_str = ast_str2cmd_str(string_node);
 
-	t_cmd_str_node *tmp = cmd_str;
 	int i = 0;
-	while (tmp)
+	while (cmd_str[i])
 	{
 		printf("%d:\n", i);
-		printf("\t|%s|\n", tmp->text);
-		if (tmp->type == TOKTYPE_EXPANDABLE)
+		printf("\t|%s|\n", cmd_str[i]->text);
+		if (cmd_str[i]->type == TOKTYPE_EXPANDABLE)
 			printf("\tTOKTYPE_EXPANDABLE\n");
-		else if (tmp->type == TOKTYPE_EXPANDABLE_QUOTED)
+		else if (cmd_str[i]->type == TOKTYPE_EXPANDABLE_QUOTED)
 			printf("\tTOKTYPE_EXPANDABLE_QUOTED\n");
-		else if (tmp->type == TOKTYPE_NON_EXPANDABLE)
+		else if (cmd_str[i]->type == TOKTYPE_NON_EXPANDABLE)
 			printf("\tTOKTYPE_NON_EXPANDABLE\n");
 		else
-			printf("\tUNKNOWN: %d\n", tmp->type);
+			printf("\tUNKNOWN: %d\n", cmd_str[i]->type);
 		i++;
-		tmp = tmp->next;
 	}
 	// 中間表現構造体を文字列配列にする.
 	char	**result = cmd_str2str_arr(cmd_str);
 
-	while (cmd_str)
+	i = 0;
+	while (cmd_str[i])
 	{
-		free(cmd_str->text);
-		t_cmd_str_node *tmp = cmd_str;
-		cmd_str = cmd_str->next;
-		free(tmp);
+		free(cmd_str[i]->text);
+		free(cmd_str[i]);
+		i++;
 	}
 	return (result);
 }

--- a/expand_string_node.c
+++ b/expand_string_node.c
@@ -1,123 +1,61 @@
 #include "minishell.h"
 
-typedef struct	s_cmd_str_node {
-	char					*text;
-	t_token_type			type;
-	struct s_cmd_str_node	*next;
-}				t_cmd_str_node;
-
-static t_cmd_str_node	*cmd_str_node_add_back(t_cmd_str_node **str_node, char *text, t_token_type tok_type)
+/* 前の文字列の右端と今回の文字列左端に空白が無ければくっつける */
+static bool argv_add_arg(char ***argv, char *arg)
 {
-	t_cmd_str_node	*current_node;
-	t_cmd_str_node	*new_node;
+	char	argv_len;
 
-	new_node = ft_calloc(1, sizeof(t_cmd_str_node));
-	if (!new_node)
-		return (NULL);
-	new_node->text = text;
-	new_node->type = tok_type;
-	if (!*str_node)
+	if (!*argv)
 	{
-		*str_node = new_node;
-		return (new_node);
+		*argv = (char **)ptrarr_add_ptr((void **)argv, arg);
+		return (!!*argv);
 	}
-	current_node = *str_node;
-	while (current_node->next)
-		current_node = current_node->next;
-	current_node->next = new_node;
-	return (new_node);
-}
-
-/* ast_str_node を cmd_str_node に変換する(環境変数は展開する).
- */
-static t_cmd_str_node	*ast_str2cmd_str(t_parse_node_string *str_node)
-{
-	t_cmd_str_node	*result;
-	char			*expanded_str;
-
-	result = NULL;
-	while (str_node)
+	argv_len = ptrarr_len((void **)(*argv));
+	if ((*argv)[argv_len - 1][ft_strlen((*argv)[argv_len - 1]) - 1] != ' '
+		&& arg[ft_strlen(arg) - 1] != ' ')
 	{
-		if (str_node->type == TOKTYPE_NON_EXPANDABLE)
-			expanded_str = ft_strdup(str_node->text);
-		else
-			expanded_str = expand_env_var(str_node->text);
-		if (!cmd_str_node_add_back(&result, expanded_str, str_node->type))
-				return (NULL);
-		if (str_node->next)
-			str_node = str_node->next->content.string;
-		else
-			str_node = NULL;
+		char	*tmp = (*argv)[argv_len - 1];
+		(*argv)[argv_len - 1] = ft_strjoin((*argv)[argv_len - 1], arg);
+		free(tmp);
 	}
-	return (result);
-}
-
-/* 中間表現構造体を文字列配列にする. */
-static char	**cmd_str2str_arr(t_cmd_str_node *str_node)
-{
-	char	**result;
-	int		last_idx;
-
-	last_idx = -1;  // resultの最後の文字列への添字
-	result = NULL;
-	while (str_node)
+	else
 	{
-		// 前の文字列の右端と今回の文字列左端に空白が無ければくっつける
-		if (str_node->type == TOKTYPE_EXPANDABLE_QUOTED
-			|| str_node->type == TOKTYPE_NON_EXPANDABLE
-			&& last_idx >= 0
-			&& result[last_idx][ft_strlen(result[last_idx]) - 1] != ' '
-			&& str_node->text[0] != ' ')
-		{
-			char	*tmp = result[last_idx];
-			result[last_idx] = ft_strjoin(tmp, str_node->text);
-			free(tmp);
-		}
-		else
-		{
-			char	**tmp = result;
-			result = (char **)ptrarr_add_ptr((void **)result, ft_strdup(str_node->text));
-			free(tmp);
-			last_idx = ptrarr_len((void **)result) - 1;
-		}
-		str_node = str_node->next;
+		char **tmp = (*argv);
+		(*argv) = (char **)ptrarr_add_ptr((void **)(*argv), arg);
+		free(tmp);
 	}
-	return (result);
+	return (!!(*argv));
 }
 
 char	**expand_string_node(t_parse_node_string *string_node)
 {
-	// string_nodeを中間表現構造体(テキストとタイプを持つ)の配列に変換する.
-	t_cmd_str_node *cmd_str = ast_str2cmd_str(string_node);
-	printf("%p\n", cmd_str);
-	// 中間表現構造体を文字列配列にする.
-	char	**result = cmd_str2str_arr(cmd_str);
+	char			**result;
+	char			*expanded_str;
 
-	while (cmd_str)
+	result = NULL;
+	while (string_node)
 	{
-		free(cmd_str->text);
-		t_cmd_str_node *tmp = cmd_str;
-		cmd_str = cmd_str->next;
-		free(tmp);
+		if (string_node->type == TOKTYPE_NON_EXPANDABLE)
+			expanded_str = ft_strdup(string_node->text);
+		else
+			expanded_str = expand_env_var(string_node->text);
+		// EXPANDABLE_QUOTED なら ft_split() して追加する
+		if (string_node->type == TOKTYPE_EXPANDABLE)
+		{
+			char	**tmp = ft_split(expanded_str, ' ');
+			free(expanded_str);
+			int i = 0;
+			while (tmp[i])
+				argv_add_arg(&result, tmp[i++]);
+			free(tmp);
+		}
+		else
+			argv_add_arg(&result, expanded_str);
+		if (string_node->next)
+			string_node = string_node->next->content.string;
+		else
+			string_node = NULL;
 	}
 	return (result);
 }
 
-// /*
-//  * 一度文字列を全て展開した上でexpanded_strarrを生成する
-//  */
-// char	**expand_string_node(t_parse_node_string *string_node)
-// {
-// 	char	*restored_str;
-// 	char	*expanded_str;
-// 	char	**splitted_expanded_str;
-// 
-// 	restored_str = string_node2string(string_node);
-// 	printf("restored_str: |%s|\n", restored_str);
-// 	expanded_str = expand_env_var(restored_str);
-// 	free(restored_str);
-// 	printf("expanded_str: |%s|\n", expanded_str);
-// 	splitted_expanded_str = split_expanded_str(expanded_str);
-// 	free(expanded_str);
-// 	return (splitted_expanded_str);
-// }

--- a/expand_string_node.c
+++ b/expand_string_node.c
@@ -55,12 +55,17 @@ static char	**cmd_str2str_arr(t_cmd_str_node **str_node)
 	result = NULL;
 	while (str_node[i])
 	{
-		// 前の文字列の右端と今回の文字列左端に空白が無ければくっつける
 		int j = 0;
 		while (str_node[i]->text[j])
-		{
-			
-		}
+		// EXPANDABLEのの最後の文字列の後に空白が無ければ次とくっつける
+			if (str_node[i]->type == TOKTYPE_EXPANDABLE)
+			{
+				
+			}
+			else
+			{
+
+			}
 		i++;
 	}
 	return (result);

--- a/expand_string_node.c
+++ b/expand_string_node.c
@@ -48,38 +48,31 @@ static t_cmd_str_node	**ast_str2cmd_str(t_parse_node_string *str_node)
 
 static void	cmd_str_expandable2str_arr(char ***result, char **next_str, t_cmd_str_node *str_node)
 {
-	int		start;
-	int		end;
-	char	*tmp;
+	int		len;
+	char	*str;
 	char	**tmparr;
 
-	start = 0;
-	end = 0;
-	while (str_node->text[end])
+	len = 0;
+	str = str_node->text;
+	while (str[len])
 	{
-		if (str_node->text[end] == ' ' && start - end == 0)
+		if (str[len] == ' ' && len == 0)
+			str++;
+		else if (str[len] == ' ' && len)
 		{
-			start++;
-			end++;
-		}
-		else if (str_node->text[end] == ' ' && start - end)
-		{
-			*next_str = strjoin_and_free_both(*next_str, ft_substr(str_node->text, start, end - start));
+			*next_str = strjoin_and_free_both(*next_str, ft_substr(str, 0, len));
 			tmparr = *result;
 			*result = (char **)ptrarr_add_ptr((void **)*result, *next_str);
 			free(tmparr);
 			*next_str = ft_strdup("");
-			end++;
-			start = end;
+			str += len + 1;
+			len = 0;
 		}
 		else
-			end++;
+			len++;
 	}
-	if (start - end)
-	{
-		tmp = ft_substr(str_node->text, start, end - start);
-		*next_str = strjoin_and_free_both(*next_str, tmp);
-	}
+	if (len)
+		*next_str = strjoin_and_free_both(*next_str, ft_substr(str, 0, len));
 }
 
 /* 中間表現構造体を文字列配列にする. */
@@ -88,6 +81,7 @@ static char	**cmd_str2str_arr(t_cmd_str_node **str_node)
 	char	**result;
 	char	*next_str;  // 次resultに追加される文字列
 	int		i;
+	char	**tmparr;
 
 	i = 0;
 	result = NULL;
@@ -95,20 +89,14 @@ static char	**cmd_str2str_arr(t_cmd_str_node **str_node)
 	while (str_node[i])
 	{
 		if (str_node[i]->type != TOKTYPE_EXPANDABLE)
-		{
-			char *tmp = next_str;
-			next_str = ft_strjoin(next_str, str_node[i]->text);
-			free(tmp);
-		}
+			next_str = strjoin_and_free_first(next_str, str_node[i]->text);
 		else
 			cmd_str_expandable2str_arr(&result, &next_str, str_node[i]);
 		i++;
 	}
 	if (next_str && ft_strlen(next_str))
 	{
-		char	**tmparr;
 		tmparr = result;
-					printf("\t\tadd: |%s|\n", next_str);
 		result = (char **)ptrarr_add_ptr((void **)result, next_str);
 		free(tmparr);
 	}

--- a/expand_string_node.c
+++ b/expand_string_node.c
@@ -68,11 +68,8 @@ static char	*expandable_node2strarr(char ***result,
 			text++;
 		else if (text[len] == ' ' && len)
 		{
-			if (next_str)
-				next_str = strjoin_and_free_both(next_str,
-						ft_substr(text, 0, len));
-			else
-				next_str = ft_substr(text, 0, len);
+			next_str = strjoin_nullable_and_free_both(
+				next_str, ft_substr(text, 0, len));
 			*result = (char **)ptrarr_add_ptr_and_free((void **)*result,
 					next_str);
 			next_str = NULL;
@@ -85,12 +82,8 @@ static char	*expandable_node2strarr(char ***result,
 			len++;
 	}
 	if (len)
-	{
-		if (next_str)
-			next_str = strjoin_and_free_both(next_str, ft_substr(text, 0, len));
-		else
-			next_str = ft_substr(text, 0, len);
-	}
+		next_str = strjoin_nullable_and_free_both(
+			next_str, ft_substr(text, 0, len));
 	return (next_str);
 }
 

--- a/expand_string_node.c
+++ b/expand_string_node.c
@@ -46,7 +46,8 @@ static t_cmd_str_node	**ast_str2cmd_str(t_parse_node_string *str_node)
 	return ((t_cmd_str_node **)result);
 }
 
-static void	cmd_str_expandable2str_arr(char ***result,
+/* TOKTYPE_EXPANDABLEを処理する */
+static bool	cmd_str_expandable2str_arr(char ***result,
 	char **next_str, char *text)
 {
 	int		len;
@@ -63,6 +64,8 @@ static void	cmd_str_expandable2str_arr(char ***result,
 			*result = (char **)ptrarr_add_ptr_and_free((void **)*result,
 					*next_str);
 			*next_str = ft_strdup("");
+			if (!*result || !*next_str)
+				return (false);
 			text += len + 1;
 			len = 0;
 		}
@@ -71,6 +74,7 @@ static void	cmd_str_expandable2str_arr(char ***result,
 	}
 	if (len)
 		*next_str = strjoin_and_free_both(*next_str, ft_substr(text, 0, len));
+	return (!!*next_str);
 }
 
 /* 中間表現構造体を文字列配列にする. */
@@ -79,7 +83,6 @@ static char	**cmd_str2str_arr(t_cmd_str_node **str_node)
 	char	**result;
 	char	*next_str;
 	int		i;
-	char	**tmparr;
 
 	i = 0;
 	result = NULL;
@@ -93,11 +96,7 @@ static char	**cmd_str2str_arr(t_cmd_str_node **str_node)
 		i++;
 	}
 	if (next_str && ft_strlen(next_str))
-	{
-		tmparr = result;
-		result = (char **)ptrarr_add_ptr((void **)result, next_str);
-		free(tmparr);
-	}
+		result = (char **)ptrarr_add_ptr_and_free((void **)result, next_str);
 	else
 		free(next_str);
 	return (result);

--- a/expand_string_node.c
+++ b/expand_string_node.c
@@ -1,7 +1,8 @@
 #include "minishell.h"
 #include "utils.h"
 
-static bool	cmd_str_node_add_back(t_cmd_str_node ***str_node_arr, char *text, t_token_type tok_type)
+static bool	cmd_str_node_add_back(t_cmd_str_node ***str_node_arr,
+	char *text, t_token_type tok_type)
 {
 	t_cmd_str_node	*new_node;
 	t_cmd_str_node	**tmp;
@@ -12,7 +13,8 @@ static bool	cmd_str_node_add_back(t_cmd_str_node ***str_node_arr, char *text, t_
 	new_node->text = text;
 	new_node->type = tok_type;
 	tmp = *str_node_arr;
-	*str_node_arr = (t_cmd_str_node **)ptrarr_add_ptr((void **)*str_node_arr, new_node);
+	*str_node_arr = (t_cmd_str_node **)ptrarr_add_ptr(
+			(void **)*str_node_arr, new_node);
 	free(tmp);
 	return (true);
 }
@@ -41,11 +43,11 @@ static t_cmd_str_node	**ast_str2cmd_str(t_parse_node_string *str_node)
 	return ((t_cmd_str_node **)result);
 }
 
-static void	cmd_str_expandable2str_arr(char ***result, char **next_str, t_cmd_str_node *str_node)
+static void	cmd_str_expandable2str_arr(char ***result,
+	char **next_str, t_cmd_str_node *str_node)
 {
 	int		len;
 	char	*str;
-	char	**tmparr;
 
 	len = 0;
 	str = str_node->text;
@@ -56,9 +58,7 @@ static void	cmd_str_expandable2str_arr(char ***result, char **next_str, t_cmd_st
 		else if (str[len] == ' ' && len)
 		{
 			*next_str = strjoin_and_free_both(*next_str, ft_substr(str, 0, len));
-			tmparr = *result;
-			*result = (char **)ptrarr_add_ptr((void **)*result, *next_str);
-			free(tmparr);
+			*result = (char **)ptrarr_add_ptr_and_free((void **)*result, *next_str);
 			*next_str = ft_strdup("");
 			str += len + 1;
 			len = 0;

--- a/expand_string_node.c
+++ b/expand_string_node.c
@@ -49,25 +49,59 @@ static t_cmd_str_node	**ast_str2cmd_str(t_parse_node_string *str_node)
 static char	**cmd_str2str_arr(t_cmd_str_node **str_node)
 {
 	char	**result;
+	char	*next_str;  // 次resultに追加される文字列
 	int		i;
 
 	i = 0;
 	result = NULL;
+	next_str = ft_strdup("");
 	while (str_node[i])
 	{
-		int j = 0;
-		while (str_node[i]->text[j])
-		// EXPANDABLEのの最後の文字列の後に空白が無ければ次とくっつける
-			if (str_node[i]->type == TOKTYPE_EXPANDABLE)
+		if (str_node[i]->type != TOKTYPE_EXPANDABLE)
+		{
+			char *tmp = next_str;
+			next_str = ft_strjoin(next_str, str_node[i]->text);
+			free(tmp);
+		}
+		else
+		{
+			int start = 0;
+			int end = 0;
+			// EXPANDABLEのの最後の文字列の後に空白が無ければ次とくっつける
+			while (str_node[i]->text[end])
 			{
-				
-			}
-			else
-			{
+				if (str_node[i]->text[end] == ' ' && start - end == 0)
+				{
+					start++;
+					end++;
+				}
+				if ((str_node[i]->text[end] == ' ' && start - end > 0) || !str_node[i]->text[end])
+				{
+					char *tmp = next_str;
+					next_str = ft_strjoin(next_str, ft_substr(str_node[i]->text, start, end - start));
+					free(tmp);
 
+					char	**tmparr;
+					tmparr = result;
+					result = (char **)ptrarr_add_ptr((void **)result, next_str);
+					free(tmparr);
+					next_str = ft_strdup("");
+				}
+				else
+					end++;
 			}
+		}
 		i++;
 	}
+	if (next_str && ft_strlen(next_str))
+	{
+		char	**tmparr;
+		tmparr = result;
+		result = (char **)ptrarr_add_ptr((void **)result, next_str);
+		free(tmparr);
+	}
+	else
+		free(next_str);
 	return (result);
 }
 

--- a/libft/libft.h
+++ b/libft/libft.h
@@ -72,6 +72,7 @@ void				free_ptrarr(void **ptrarr);
 void				*free_ptrarr_and_rtn_null(void **ptrarr);
 void				free_ptrarr_and_assign_null(void ***ptrarr);
 void				**ptrarr_add_ptr(void **ptrarr, void *ptr);
+void				**ptrarr_add_ptr_and_free(void **ptrarr, void *ptr);
 void				**ptrarr_merge(void **ptrarr_first, void **ptrarr_last);
 int					wrap_malloc(void **p, size_t len);
 

--- a/libft/ptrarr_utils2.c
+++ b/libft/ptrarr_utils2.c
@@ -22,3 +22,12 @@ void	**ptrarr_merge(void **ptrarr_first, void **ptrarr_last)
 		sizeof(void *) * last_len);
 	return (ptrarr_new);
 }
+
+void	**ptrarr_add_ptr_and_free(void **ptrarr, void *ptr)
+{
+	void **result;
+
+	result = ptrarr_add_ptr(ptrarr, ptr);
+	free(ptrarr);
+	return (result);
+}

--- a/libft/ptrarr_utils2.c
+++ b/libft/ptrarr_utils2.c
@@ -25,7 +25,7 @@ void	**ptrarr_merge(void **ptrarr_first, void **ptrarr_last)
 
 void	**ptrarr_add_ptr_and_free(void **ptrarr, void *ptr)
 {
-	void **result;
+	void	**result;
 
 	result = ptrarr_add_ptr(ptrarr, ptr);
 	free(ptrarr);

--- a/minishell.h
+++ b/minishell.h
@@ -13,6 +13,7 @@
 
 # define PROMPT "minish > "
 
+// AST から exec_and_args に変換する時に使う構造体
 typedef struct s_cmd_str_node {
 	char					*text;
 	t_token_type			type;

--- a/minishell.h
+++ b/minishell.h
@@ -13,11 +13,10 @@
 
 # define PROMPT "minish > "
 
-typedef struct	s_cmd_str_node {
+typedef struct s_cmd_str_node {
 	char					*text;
 	t_token_type			type;
 }				t_cmd_str_node;
-
 
 // AST to command_invocation
 t_command_invocation	*cmd_ast_pipcmds2cmdinvo(t_parse_node_pipcmds *pipcmds);

--- a/minishell.h
+++ b/minishell.h
@@ -13,6 +13,12 @@
 
 # define PROMPT "minish > "
 
+typedef struct	s_cmd_str_node {
+	char					*text;
+	t_token_type			type;
+}				t_cmd_str_node;
+
+
 // AST to command_invocation
 t_command_invocation	*cmd_ast_pipcmds2cmdinvo(t_parse_node_pipcmds *pipcmds);
 t_command_invocation	*cmd_ast_cmd2cmdinvo(t_parse_node_command *cmd_node);

--- a/split_expanded_str.c
+++ b/split_expanded_str.c
@@ -84,6 +84,10 @@ static char	*get_str_from_expanded_str(char **str)
 
 /*
  * 環境変数展開した文字列を分解して返す
+ *
+ * ex:
+ *   in($ABC="hoge"):       |'$''$'"ABC"'\'"$ABC""$ABC"|
+ *   out:                   ["$$ABC\hogehoge"]
  */
 char	**split_expanded_str(char *str)
 {

--- a/str_utils.c
+++ b/str_utils.c
@@ -28,7 +28,7 @@ char	*strjoin_and_free_both(char *first, char *second)
 
 char	*strjoin_nullable_and_free_both(char *str_nullable, char *second)
 {
-	char *result;
+	char	*result;
 
 	if (str_nullable)
 		result = ft_strjoin(str_nullable, second);

--- a/str_utils.c
+++ b/str_utils.c
@@ -25,4 +25,3 @@ char	*strjoin_and_free_both(char *first, char *second)
 	free(second);
 	return (result);
 }
-

--- a/str_utils.c
+++ b/str_utils.c
@@ -1,0 +1,16 @@
+#include "utils.h"
+#include "../libft/libft.h"
+
+/*
+ * first に second を繋げて, firstだけfreeする
+ */
+char	*strjoin_and_free_first(char *first, char *second)
+{
+	char	*tmp;
+
+	tmp = first;
+	first = ft_strjoin(first, second);
+	free(tmp);
+	return (first);
+}
+

--- a/str_utils.c
+++ b/str_utils.c
@@ -29,6 +29,8 @@ char	*strjoin_and_free_both(char *first, char *second)
 /*
  * str_nullable がtruthyだったら, strjoin(str_nullable, second) を返し,
  * そうでない場合 strdup(second) を返す.
+ *
+ * str_nullable と second は free される.
  */
 char	*strjoin_nullable_and_free_both(char *str_nullable, char *second)
 {

--- a/str_utils.c
+++ b/str_utils.c
@@ -26,6 +26,10 @@ char	*strjoin_and_free_both(char *first, char *second)
 	return (result);
 }
 
+/*
+ * str_nullable がtruthyだったら, strjoin(str_nullable, second) を返し,
+ * そうでない場合 ft_strdup(second) を返す.
+ */
 char	*strjoin_nullable_and_free_both(char *str_nullable, char *second)
 {
 	char	*result;

--- a/str_utils.c
+++ b/str_utils.c
@@ -6,11 +6,23 @@
  */
 char	*strjoin_and_free_first(char *first, char *second)
 {
-	char	*tmp;
+	char	*result;
 
-	tmp = first;
-	first = ft_strjoin(first, second);
-	free(tmp);
-	return (first);
+	result = ft_strjoin(first, second);
+	free(first);
+	return (result);
+}
+
+/*
+ * first に second を繋げて, firstとsecondをfreeする
+ */
+char	*strjoin_and_free_both(char *first, char *second)
+{
+	char	*result;
+
+	result = ft_strjoin(first, second);
+	free(first);
+	free(second);
+	return (result);
 }
 

--- a/str_utils.c
+++ b/str_utils.c
@@ -25,3 +25,16 @@ char	*strjoin_and_free_both(char *first, char *second)
 	free(second);
 	return (result);
 }
+
+char	*strjoin_nullable_and_free_both(char *str_nullable, char *second)
+{
+	char *result;
+
+	if (str_nullable)
+		result = ft_strjoin(str_nullable, second);
+	else
+		result = ft_strdup(second);
+	free(str_nullable);
+	free(second);
+	return (result);
+}

--- a/str_utils.c
+++ b/str_utils.c
@@ -1,5 +1,5 @@
 #include "utils.h"
-#include "../libft/libft.h"
+#include "libft/libft.h"
 
 /*
  * first に second を繋げて, firstだけfreeする

--- a/str_utils.c
+++ b/str_utils.c
@@ -28,7 +28,7 @@ char	*strjoin_and_free_both(char *first, char *second)
 
 /*
  * str_nullable がtruthyだったら, strjoin(str_nullable, second) を返し,
- * そうでない場合 ft_strdup(second) を返す.
+ * そうでない場合 strdup(second) を返す.
  */
 char	*strjoin_nullable_and_free_both(char *str_nullable, char *second)
 {

--- a/string_node2string.c
+++ b/string_node2string.c
@@ -1,17 +1,5 @@
 #include "minishell.h"
-
-/*
- * first に second を繋げて, firstだけfreeする
- */
-static char	*strjoin_and_free_first(char *first, char *second)
-{
-	char	*tmp;
-
-	tmp = first;
-	first = ft_strjoin(first, second);
-	free(tmp);
-	return (first);
-}
+#include "utils.h"
 
 /* string_nodeを文字列に戻す
  *うまくいけばASTの時点でこの文字列になるように依頼する

--- a/test/Makefile
+++ b/test/Makefile
@@ -10,7 +10,8 @@ SRCS = 	../env.c ../env_setter.c ../path.c ../g_cwd.c												\
 		../cmd_status.c ../signal.c ../cmd_status.c ../signal.c ../minishell_error_msg.c			\
 		../builtin.c ../builtin_echo.c ../builtin_env.c												\
 		../builtin_cd.c ../builtin_cd_path.c ../builtin_cd_chdir.c ../builtin_cd_cdpath.c			\
-		../builtin_exit.c ../builtin_export.c ../builtin_pwd.c ../builtin_unset.c
+		../builtin_exit.c ../builtin_export.c ../builtin_pwd.c ../builtin_unset.c					\
+		../str_utils.c
 HEADERS = ../env.h \
 		  ../parse.h \
 		  ../execution.h \

--- a/test/ast2cmdinvo_test.c
+++ b/test/ast2cmdinvo_test.c
@@ -312,7 +312,7 @@ int main()
 	TEST_SECTION("expand_string_node() エスケープされた環境変数");
 	{
 		/* 準備 */
-		setenv("ABC", "abc def", 1);
+		setenv("ABC", " abc def ", 1);
 		t_parse_buffer	buf;
 		init_buf_with_string(&buf, "echo \"\\$\\$ABC\\\\$ABC\"\"$ABC\" \n");
 		t_token	tok;
@@ -355,10 +355,10 @@ int main()
 		char **actual = expand_string_node(args_node->string_node->content.string);
 		char **expected = NULL;
 		char **tmp = expected;
-		expected = (char **)ptrarr_add_ptr((void **)expected, ft_strdup("$$ABC\\abc def"));
+		expected = (char **)ptrarr_add_ptr((void **)expected, ft_strdup("$$ABC\\ abc def "));
 		free(tmp);
 		tmp = expected;
-		expected = (char **)ptrarr_add_ptr((void **)expected, ft_strdup("abc def"));
+		expected = (char **)ptrarr_add_ptr((void **)expected, ft_strdup(" abc def "));
 		free(tmp);
 
 		check_strarr((const char **)actual, (const char **)expected);

--- a/test/ast2cmdinvo_test.c
+++ b/test/ast2cmdinvo_test.c
@@ -284,13 +284,17 @@ int main()
 		t_parse_node_arguments *args_node = node->content.command->arguments_node->content.arguments;
 		CHECK_EQ(args_node->string_node->content.string->type, TOKTYPE_EXPANDABLE);
 		CHECK_EQ_STR(args_node->string_node->content.string->text, "echo");
+
 		args_node = args_node->rest_node->content.arguments;
+
 		t_parse_node_string *string_node = args_node->string_node->content.string;
 		CHECK_EQ(string_node->type, TOKTYPE_EXPANDABLE);
 		CHECK_EQ_STR(string_node->text, "hoge$ABC");
+
 		string_node = string_node->next->content.string;
 		CHECK_EQ(string_node->type, TOKTYPE_EXPANDABLE_QUOTED);
 		CHECK_EQ_STR(string_node->text, "hoge hoge");
+
 		string_node = string_node->next->content.string;
 		CHECK_EQ(string_node->type, TOKTYPE_NON_EXPANDABLE);
 		CHECK_EQ_STR(string_node->text, "$ABC");
@@ -365,7 +369,6 @@ int main()
 		free_ptrarr((void **)actual);
 		free_ptrarr((void **)expected);
 	}
-	return (0);
 
 
 	TEST_CHAPTER("AST to command_invocation");

--- a/test/ast2cmdinvo_test.c
+++ b/test/ast2cmdinvo_test.c
@@ -312,7 +312,7 @@ int main()
 	TEST_SECTION("expand_string_node() エスケープされた環境変数");
 	{
 		/* 準備 */
-		setenv("ABC", "hoge", 1);
+		setenv("ABC", "abc def", 1);
 		t_parse_buffer	buf;
 		init_buf_with_string(&buf, "echo \"\\$\\$ABC\\\\$ABC\"\"$ABC\" \n");
 		t_token	tok;
@@ -355,7 +355,10 @@ int main()
 		char **actual = expand_string_node(args_node->string_node->content.string);
 		char **expected = NULL;
 		char **tmp = expected;
-		expected = (char **)ptrarr_add_ptr((void **)expected, ft_strdup("$$ABC\\hogehoge"));
+		expected = (char **)ptrarr_add_ptr((void **)expected, ft_strdup("$$ABC\\abc def"));
+		free(tmp);
+		tmp = expected;
+		expected = (char **)ptrarr_add_ptr((void **)expected, ft_strdup("abc def"));
 		free(tmp);
 
 		check_strarr((const char **)actual, (const char **)expected);

--- a/test/ast2cmdinvo_test.c
+++ b/test/ast2cmdinvo_test.c
@@ -320,6 +320,7 @@ int main()
 		/* 準備 */
 		setenv("ABC", " abc def ", 1);
 		t_parse_buffer	buf;
+		// echo "\$\$ABC\\$ABC""$ABC"
 		init_buf_with_string(&buf, "echo \"\\$\\$ABC\\\\$ABC\"\"$ABC\" \n");
 		t_token	tok;
 
@@ -361,10 +362,7 @@ int main()
 		char **actual = expand_string_node(args_node->string_node->content.string);
 		char **expected = NULL;
 		char **tmp = expected;
-		expected = (char **)ptrarr_add_ptr((void **)expected, ft_strdup("$$ABC\\ abc def "));
-		free(tmp);
-		tmp = expected;
-		expected = (char **)ptrarr_add_ptr((void **)expected, ft_strdup(" abc def "));
+		expected = (char **)ptrarr_add_ptr((void **)expected, ft_strdup("$$ABC\\ abc def  abc def "));
 		free(tmp);
 
 		check_strarr((const char **)actual, (const char **)expected);

--- a/test/ast2cmdinvo_test.c
+++ b/test/ast2cmdinvo_test.c
@@ -274,6 +274,8 @@ int main()
 		setenv("ABC", "abc def", 1);
 		t_parse_buffer	buf;
 		init_buf_with_string(&buf, "echo hoge$ABC\"hoge hoge\"'$ABC' \n");
+		// "hogeabc def\"hoge hoge\"$ABC"
+		// ["hoge abc def ", "hoge hoge", "$ABC"]-> ["hoge", "abc", "def", "hoge hoge$ABC"]
 		t_token	tok;
 
 		lex_get_token(&buf, &tok);

--- a/test/ast2cmdinvo_test.c
+++ b/test/ast2cmdinvo_test.c
@@ -324,7 +324,7 @@ int main()
 		lex_get_token(&buf, &tok);
 
 		t_parse_ast *node = parse_command(&buf, &tok);
-        CHECK_EQ(node->type, ASTNODE_COMMAND);
+		CHECK_EQ(node->type, ASTNODE_COMMAND);
 		CHECK_EQ(node->content.command->arguments_node->type, ASTNODE_ARGUMENTS);
 		t_parse_node_arguments *args_node = node->content.command->arguments_node->content.arguments;
 		CHECK_EQ(args_node->string_node->content.string->type, TOKTYPE_EXPANDABLE);
@@ -427,7 +427,7 @@ int main()
 		lex_get_token(&buf, &tok);
 
 		t_parse_ast *node = parse_command(&buf, &tok);
-        CHECK_EQ(node->type, ASTNODE_COMMAND);
+		CHECK_EQ(node->type, ASTNODE_COMMAND);
 		CHECK_EQ(node->content.command->arguments_node->type, ASTNODE_ARGUMENTS);
 		t_parse_node_arguments *args_node = node->content.command->arguments_node->content.arguments;
 		CHECK_EQ(args_node->string_node->content.string->type, TOKTYPE_EXPANDABLE);

--- a/test/ast2cmdinvo_test.c
+++ b/test/ast2cmdinvo_test.c
@@ -314,7 +314,7 @@ int main()
 		/* 準備 */
 		setenv("ABC", "hoge", 1);
 		t_parse_buffer	buf;
-		init_buf_with_string(&buf, "echo \"\\$\\$ABC\\\\$ABC\"\"$ABC\"");
+		init_buf_with_string(&buf, "echo \"\\$\\$ABC\\\\$ABC\"\"$ABC\" \n");
 		t_token	tok;
 
 		lex_get_token(&buf, &tok);

--- a/test/ast2cmdinvo_test.c
+++ b/test/ast2cmdinvo_test.c
@@ -235,7 +235,6 @@ int main()
 		unsetenv("ABC");
 	}
 
-	// TODO: これでargs_nodeのコマンド引数展開がうまくいけそうならこの処理はparser側でやってもらう
 	TEST_SECTION("string_node2string()");
 	{
 		/* 準備 */
@@ -368,7 +367,6 @@ int main()
 		free_ptrarr((void **)expected);
 	}
 
-
 	TEST_CHAPTER("AST to command_invocation");
 
 	TEST_SECTION("cmd_ast_cmd2cmdinvo 文字列1つ");
@@ -411,6 +409,80 @@ int main()
 		/* テスト */
 		t_command_invocation *actual = cmd_ast_cmd2cmdinvo(node->content.command);
 		t_command_invocation *expected = cmd_init_cmdinvo((const char **)ft_split("abc def", ' '));
+		CHECK(actual);
+		check_cmdinvo(actual, expected);
+
+		cmd_free_cmdinvo(actual);
+		cmd_free_cmdinvo(expected);
+	}
+
+	TEST_SECTION("cmd_ast_cmd2cmdinvo() 空文字列を含む");
+	{
+		/* 準備 */
+		t_parse_buffer	buf;
+		// echo a "" b "" c
+		init_buf_with_string(&buf, "echo a \"\" b \"\" c\n");
+		t_token	tok;
+
+		lex_get_token(&buf, &tok);
+
+		t_parse_ast *node = parse_command(&buf, &tok);
+        CHECK_EQ(node->type, ASTNODE_COMMAND);
+		CHECK_EQ(node->content.command->arguments_node->type, ASTNODE_ARGUMENTS);
+		t_parse_node_arguments *args_node = node->content.command->arguments_node->content.arguments;
+		CHECK_EQ(args_node->string_node->content.string->type, TOKTYPE_EXPANDABLE);
+		CHECK_EQ_STR(args_node->string_node->content.string->text, "echo");
+
+		args_node = args_node->rest_node->content.arguments;
+
+		t_parse_node_string *string_node = args_node->string_node->content.string;
+		CHECK_EQ(string_node->type, TOKTYPE_EXPANDABLE);
+		CHECK_EQ_STR(string_node->text, "a");
+
+		args_node = args_node->rest_node->content.arguments;
+		string_node = args_node->string_node->content.string;
+		CHECK_EQ(string_node->type, TOKTYPE_EXPANDABLE_QUOTED);
+		CHECK_EQ_STR(string_node->text, "");
+
+		args_node = args_node->rest_node->content.arguments;
+		string_node = args_node->string_node->content.string;
+		CHECK_EQ(string_node->type, TOKTYPE_EXPANDABLE);
+		CHECK_EQ_STR(string_node->text, "b");
+
+		args_node = args_node->rest_node->content.arguments;
+		string_node = args_node->string_node->content.string;
+		CHECK_EQ(string_node->type, TOKTYPE_EXPANDABLE_QUOTED);
+		CHECK_EQ_STR(string_node->text, "");
+
+		args_node = args_node->rest_node->content.arguments;
+		string_node = args_node->string_node->content.string;
+		CHECK_EQ(string_node->type, TOKTYPE_EXPANDABLE);
+		CHECK_EQ_STR(string_node->text, "c");
+
+		/* テスト */
+		t_command_invocation *actual = cmd_ast_cmd2cmdinvo(node->content.command);
+		t_command_invocation *expected = cmd_init_cmdinvo(NULL);
+
+		const char **tmp;
+		tmp = expected->exec_and_args;
+		expected->exec_and_args = (const char**)ptrarr_add_ptr((void **)tmp, ft_strdup("echo"));
+		free(tmp);
+		tmp = expected->exec_and_args;
+		expected->exec_and_args = (const char**)ptrarr_add_ptr((void **)tmp, ft_strdup("a"));
+		free(tmp);
+		tmp = expected->exec_and_args;
+		expected->exec_and_args = (const char**)ptrarr_add_ptr((void **)tmp, ft_strdup(""));
+		free(tmp);
+		tmp = expected->exec_and_args;
+		expected->exec_and_args = (const char**)ptrarr_add_ptr((void **)tmp, ft_strdup("b"));
+		free(tmp);
+		tmp = expected->exec_and_args;
+		expected->exec_and_args = (const char**)ptrarr_add_ptr((void **)tmp, ft_strdup(""));
+		free(tmp);
+		tmp = expected->exec_and_args;
+		expected->exec_and_args = (const char**)ptrarr_add_ptr((void **)tmp, ft_strdup("c"));
+		free(tmp);
+
 		CHECK(actual);
 		check_cmdinvo(actual, expected);
 

--- a/test/ast2cmdinvo_test.c
+++ b/test/ast2cmdinvo_test.c
@@ -274,8 +274,6 @@ int main()
 		setenv("ABC", "abc def", 1);
 		t_parse_buffer	buf;
 		init_buf_with_string(&buf, "echo hoge$ABC\"hoge hoge\"'$ABC' \n");
-		// "hogeabc def\"hoge hoge\"$ABC"
-		// ["hoge abc def ", "hoge hoge", "$ABC"]-> ["hoge", "abc", "def", "hoge hoge$ABC"]
 		t_token	tok;
 
 		lex_get_token(&buf, &tok);

--- a/test/parse_test.c
+++ b/test/parse_test.c
@@ -205,6 +205,31 @@ void test_lexer()
 		CHECK(!strncmp(tok.text, "\\abc", 4));
 	}
 
+	TEST_SECTION("lex_get_token クォートありエスケープ2つあり");
+	{
+		t_parse_buffer	buf;
+		init_buf_with_string(&buf, "\"\\\\$ABC\" '\\\\abc'");
+		t_token	tok;
+
+		lex_get_token(&buf, &tok);
+		CHECK_EQ(tok.type, TOKTYPE_NON_EXPANDABLE);
+		CHECK_EQ(tok.length, 1);
+		CHECK(!strncmp(tok.text, "\\", 1));
+
+		lex_get_token(&buf, &tok);
+		CHECK_EQ(tok.type, TOKTYPE_EXPANDABLE_QUOTED);
+		CHECK_EQ(tok.length, 4);
+		CHECK(!strncmp(tok.text, "$ABC", 4));
+
+		lex_get_token(&buf, &tok);
+		CHECK_EQ(tok.type, TOKTYPE_SPACE);
+
+		lex_get_token(&buf, &tok);
+		CHECK_EQ(tok.type, TOKTYPE_NON_EXPANDABLE);
+		CHECK_EQ(tok.length, 5);
+		CHECK(!strncmp(tok.text, "\\\\abc", 5));
+	}
+
 	TEST_SECTION("lex_get_token 数字だけのトークン");
 	{
 		t_parse_buffer	buf;

--- a/test/test.c
+++ b/test/test.c
@@ -1,20 +1,23 @@
 #include <stdint.h>
 #include <stdio.h>
+#include <stdbool.h>
 
 int	g_success_count = 0;
 int	g_fail_count = 0;
 
-void	test_check(int64_t val, const char *msg)
+bool	test_check(int64_t val, const char *msg)
 {
 	if (val)
 	{
 		g_success_count++;
 		printf("  ✔ %s\n", msg);
+		return (true);
 	}
 	else
 	{
 		g_fail_count++;
 		printf("  ✖ %s\n", msg);
+		return (false);
 	}
 }
 

--- a/test/test.h
+++ b/test/test.h
@@ -5,11 +5,15 @@
 #include <unistd.h>
 
 #define CHECK(val) test_check((int64_t)val, #val)
-#define CHECK_EQ(actual, expected) test_check(actual == expected, #actual " == " #expected)
+#define CHECK_EQ(actual, expected) \
+  do { \
+	test_check(actual == expected, #actual " == " #expected); \
+	printf("    %d == %d\n", actual, expected); \
+  } while(0);
 #define CHECK_EQ_STR(actual, expected) \
   do { \
-	printf("  |%s| == |%s|\n", actual, expected); \
 	test_check(strcmp(actual, expected) == 0, #actual " == " #expected); \
+	printf("    |%s| == |%s|\n", actual, expected); \
   } while(0);
 #define TEST_CHAPTER(message) printf("#\n# " message "\n#\n")
 #define TEST_SECTION(message) printf("- " message "\n")

--- a/test/test.h
+++ b/test/test.h
@@ -5,11 +5,7 @@
 #include <unistd.h>
 
 #define CHECK(val) test_check((int64_t)val, #val)
-#define CHECK_EQ(actual, expected) \
-  do { \
-	test_check(actual == expected, #actual " == " #expected); \
-	printf("    %d == %d\n", actual, expected); \
-  } while(0);
+#define CHECK_EQ(actual, expected) test_check(actual == expected, #actual " == " #expected)
 #define CHECK_EQ_STR(actual, expected) \
   do { \
 	test_check(strcmp(actual, expected) == 0, #actual " == " #expected); \

--- a/test/test.h
+++ b/test/test.h
@@ -3,6 +3,7 @@
 #include <stdint.h>
 #include <stdlib.h>
 #include <unistd.h>
+#include <stdbool.h>
 
 #define CHECK(val) test_check((int64_t)val, #val)
 #define CHECK_EQ(actual, expected) test_check(actual == expected, #actual " == " #expected)
@@ -14,7 +15,7 @@
 #define TEST_CHAPTER(message) printf("#\n# " message "\n#\n")
 #define TEST_SECTION(message) printf("- " message "\n")
 
-void	test_check(int64_t val, const char *msg);
+bool	test_check(int64_t val, const char *msg);
 int	print_result();
 
 extern int	g_success_count;

--- a/test/test.h
+++ b/test/test.h
@@ -9,9 +9,9 @@
 #define CHECK_EQ(actual, expected) test_check(actual == expected, #actual " == " #expected)
 #define CHECK_EQ_STR(actual, expected) \
   do { \
-	test_check(strcmp(actual, expected) == 0, #actual " == " #expected); \
-	printf("    |%s| == |%s|\n", actual, expected); \
-  } while(0);
+	if (!test_check(strcmp(actual, expected) == 0, #actual " == " #expected)) \
+		printf("    |%s| == |%s|\n", actual, expected); \
+  } while(0)
 #define TEST_CHAPTER(message) printf("#\n# " message "\n#\n")
 #define TEST_SECTION(message) printf("- " message "\n")
 

--- a/utils.h
+++ b/utils.h
@@ -3,5 +3,6 @@
 
 char	*strjoin_and_free_first(char *first, char *second);
 char	*strjoin_and_free_both(char *first, char *second);
+char	*strjoin_nullable_and_free_both(char *str_nullable, char *second);
 
 #endif

--- a/utils.h
+++ b/utils.h
@@ -1,0 +1,6 @@
+#ifndef UTILS_H
+# define UTILS_H
+
+char	*strjoin_and_free_first(char *first, char *second);
+
+#endif

--- a/utils.h
+++ b/utils.h
@@ -2,5 +2,6 @@
 # define UTILS_H
 
 char	*strjoin_and_free_first(char *first, char *second);
+char	*strjoin_and_free_both(char *first, char *second);
 
 #endif


### PR DESCRIPTION
fix #93 

AST(`t_parse_node_string`)から `cmd_invocation` へ変換する `expand_string_node()` にてエスケープを正しく処理できるようにした.