### PR TITLE
ダブルクオート内のエスケープの挙動を修正

### DIFF
--- a/lexer3.c
+++ b/lexer3.c
@@ -27,7 +27,6 @@ int	lex_check_redirection_with_fd(t_parse_buffer *buf, t_token *result)
 	return (1);
 }
 
-#include <stdio.h>
 int	lex_escaped(t_parse_buffer *buf, t_token *result)
 {
 	char	ch;
@@ -36,10 +35,9 @@ int	lex_escaped(t_parse_buffer *buf, t_token *result)
 	if (ch == '\\')
 	{
 		ch = lex_getc(buf);
-		// printf("escaped_char: %c\n", ch);
 		if (buf->lex_stat == LEXSTAT_NORMAL
 			|| (buf->lex_stat == LEXSTAT_DOUBLE_QUOTED
-				&& (ch == '$' || ch == '\"' || ch == '\'' || ch == '\\' || ch == '`')))
+				&& ft_strchr("$\"\'\\`", ch)))
 		{
 			result->text[0] = ch;
 			result->length = 1;

--- a/lexer3.c
+++ b/lexer3.c
@@ -27,6 +27,7 @@ int	lex_check_redirection_with_fd(t_parse_buffer *buf, t_token *result)
 	return (1);
 }
 
+#include <stdio.h>
 int	lex_escaped(t_parse_buffer *buf, t_token *result)
 {
 	char	ch;
@@ -35,7 +36,18 @@ int	lex_escaped(t_parse_buffer *buf, t_token *result)
 	if (ch == '\\')
 	{
 		ch = lex_getc(buf);
-		result->text[0] = ch;
+		// printf("escaped_char: %c\n", ch);
+		if (buf->lex_stat == LEXSTAT_NORMAL
+			|| (buf->lex_stat == LEXSTAT_DOUBLE_QUOTED
+				&& (ch == '$' || ch == '\"' || ch == '\'' || ch == '\\' || ch == '`')))
+		{
+			result->text[0] = ch;
+			result->length = 1;
+			result->type = TOKTYPE_NON_EXPANDABLE;
+			return (1);
+		}
+		lex_ungetc(buf);
+		result->text[0] = '\\';
 		result->length = 1;
 		result->type = TOKTYPE_NON_EXPANDABLE;
 		return (1);


### PR DESCRIPTION
Close #122 

バックスラッシュがエスケープする意味のある文字: `\`, `"`, `'`, `$`, `` ` ``

- クオート内じゃない時: バックスラッシュの後にどんな文字が来てもバックスラッシュは消えてバックスラッシュの後の文字がエスケープされた状態になる
- ダブルクオート内の時: バックスラッシュの後に特殊な文字(`\`, `"`, `'`, `$`, `` ` ``)が来たらその文字をエスケープする. そうではない場合はバックスラッシュはそのまま残す.
- シングルクオート内の時: そのまま.