### PR TITLE
閉じてないクォートや行末のバックスラッシュで死なないように修正

### DIFF
--- a/lexer.h
+++ b/lexer.h
@@ -8,6 +8,7 @@ typedef struct s_parse_buffer	t_parse_buffer;
 typedef enum e_token_type
 {
 	TOKTYPE_EOF = -1,
+	TOKTYPE_PARSE_ERROR = 0,
 	TOKTYPE_NON_EXPANDABLE = 0xc101,
 	TOKTYPE_EXPANDABLE,
 	TOKTYPE_EXPANDABLE_QUOTED,

--- a/lexer.h
+++ b/lexer.h
@@ -7,6 +7,7 @@ typedef struct s_parse_buffer	t_parse_buffer;
 
 typedef enum e_token_type
 {
+	TOKTYPE_EOF = -1,
 	TOKTYPE_NON_EXPANDABLE = 0xc101,
 	TOKTYPE_EXPANDABLE,
 	TOKTYPE_EXPANDABLE_QUOTED,
@@ -45,5 +46,6 @@ int		lex_get_quoted(t_parse_buffer *buf, t_token *result, int ch);
 int		lex_get_token(t_parse_buffer *buf, t_token *result);
 int		lex_check_redirection_with_fd(t_parse_buffer *buf, t_token *result);
 int		lex_escaped(t_parse_buffer *buf, t_token *result);
+int		lex_get_eof(t_token *result, int ch);
 
 #endif

--- a/lexer1.c
+++ b/lexer1.c
@@ -9,12 +9,7 @@ int	lex_getc(t_parse_buffer *buf)
 	if (buf->getc)
 		return (buf->getc(buf));
 	if (buf->cur_pos == buf->size)
-	{
-		buf->size = read(STDIN_FILENO, buf->buffer, sizeof(buf->buffer));
-		if (buf->size == 0)
-			return (EOF);
-		buf->cur_pos = 0;
-	}
+		return (EOF);
 	return (buf->buffer[buf->cur_pos++]);
 }
 
@@ -83,11 +78,10 @@ int	lex_get_token(t_parse_buffer *buf, t_token *result)
 	if (buf->lex_stat == LEXSTAT_NORMAL)
 	{
 		ch = lex_getc(buf);
-		if (ch == EOF)
-			return (0);
 		if (lex_get_spaces(buf, result, ch)
 			|| lex_get_symbols(buf, result, ch)
-			|| lex_get_quoted(buf, result, ch))
+			|| lex_get_quoted(buf, result, ch)
+			|| lex_get_eof(result, ch))
 			return (1);
 		result->type = TOKTYPE_EXPANDABLE;
 		lex_ungetc(buf);

--- a/lexer2.c
+++ b/lexer2.c
@@ -44,9 +44,9 @@ int	lex_read_double_quoted(t_parse_buffer *buf, t_token *result)
 	while (1)
 	{
 		ch = lex_getc(buf);
-		if (ch == '"')
+		if (ch == '"' || ch == '\n' || ch == EOF)
 			buf->lex_stat = LEXSTAT_NORMAL;
-		if (ch == '\\')
+		if (ch == '\\' || ch == '\n' || ch == EOF)
 			lex_ungetc(buf);
 		if (ch == '\\' || ch == '"' || ch == '\n' || ch == EOF)
 			break ;
@@ -65,8 +65,10 @@ int	lex_read_single_quoted(t_parse_buffer *buf, t_token *result)
 	while (1)
 	{
 		ch = lex_getc(buf);
-		if (ch == '\'')
+		if (ch == '\'' || ch == '\n' || ch == EOF)
 			buf->lex_stat = LEXSTAT_NORMAL;
+		if (ch == '\n' || ch == EOF)
+			lex_ungetc(buf);
 		if (ch == '\'' || ch == '\n' || ch == EOF)
 			break ;
 		result->text[pos++] = ch;

--- a/lexer2.c
+++ b/lexer2.c
@@ -46,6 +46,8 @@ int	lex_read_double_quoted(t_parse_buffer *buf, t_token *result)
 		ch = lex_getc(buf);
 		if (ch == '"' || ch == '\n' || ch == EOF)
 			buf->lex_stat = LEXSTAT_NORMAL;
+		if (ch == '\n' || ch == EOF)
+			result->type = TOKTYPE_PARSE_ERROR;
 		if (ch == '\\' || ch == '\n' || ch == EOF)
 			lex_ungetc(buf);
 		if (ch == '\\' || ch == '"' || ch == '\n' || ch == EOF)
@@ -68,7 +70,10 @@ int	lex_read_single_quoted(t_parse_buffer *buf, t_token *result)
 		if (ch == '\'' || ch == '\n' || ch == EOF)
 			buf->lex_stat = LEXSTAT_NORMAL;
 		if (ch == '\n' || ch == EOF)
+		{
+			result->type = TOKTYPE_PARSE_ERROR;
 			lex_ungetc(buf);
+		}
 		if (ch == '\'' || ch == '\n' || ch == EOF)
 			break ;
 		result->text[pos++] = ch;

--- a/lexer3.c
+++ b/lexer3.c
@@ -1,3 +1,4 @@
+#include <stdio.h>
 #include "libft/libft.h"
 #include "parse.h"
 
@@ -52,5 +53,15 @@ int	lex_escaped(t_parse_buffer *buf, t_token *result)
 		return (1);
 	}
 	lex_ungetc(buf);
+	return (0);
+}
+
+int	lex_get_eof(t_token *result, int ch)
+{
+	if (ch == EOF)
+	{
+		result->type = TOKTYPE_EOF;
+		return (1);
+	}
 	return (0);
 }

--- a/lexer3.c
+++ b/lexer3.c
@@ -35,9 +35,10 @@ int	lex_escaped(t_parse_buffer *buf, t_token *result)
 	if (ch == '\\')
 	{
 		ch = lex_getc(buf);
-		if (buf->lex_stat == LEXSTAT_NORMAL
-			|| (buf->lex_stat == LEXSTAT_DOUBLE_QUOTED
-				&& ft_strchr("$\"\'\\`", ch)))
+		if (ch != '\n'
+			&& (buf->lex_stat == LEXSTAT_NORMAL
+				|| (buf->lex_stat == LEXSTAT_DOUBLE_QUOTED
+					&& ft_strchr("$\"\'\\`", ch))))
 		{
 			result->text[0] = ch;
 			result->length = 1;

--- a/test/Makefile
+++ b/test/Makefile
@@ -32,8 +32,6 @@ run: parse_test env_test path_test exec_test command_exec_test ast2cmdinvo_test 
 	${VALGRIND} ./splay_test
 	${VALGRIND} ./rope_test
 
-# TODO: valgrind チェックする。
-
 SRCS_PARSE = $(wildcard ../lexer*.c ../parse*.c) ../libft/ft_memcpy.c
 SRCS_SPLAY = $(wildcard ../splay*.c)
 SRCS_ROPE = $(SRCS_SPLAY) $(wildcard ../rope*.c)	\

--- a/test/parse_test.c
+++ b/test/parse_test.c
@@ -912,14 +912,7 @@ void test_parser(void)
 
 		lex_get_token(&buf, &tok);
 		t_parse_ast *node = parse_command_line(&buf, &tok);
-
-		check_single_argument(
-			node->content.command_line->seqcmd_node
-			->content.sequential_commands
-			->pipcmd_node->content.piped_commands
-			->command_node->content.command
-			->arguments_node,
-			"abc");
+		CHECK(!node);
 	}
 
 	TEST_SECTION("parse_command_line 閉じてないシングルクォート");
@@ -930,14 +923,7 @@ void test_parser(void)
 
 		lex_get_token(&buf, &tok);
 		t_parse_ast *node = parse_command_line(&buf, &tok);
-
-		check_single_argument(
-			node->content.command_line->seqcmd_node
-			->content.sequential_commands
-			->pipcmd_node->content.piped_commands
-			->command_node->content.command
-			->arguments_node,
-			"abc");
+		CHECK(!node);
 	}
 }
 


### PR DESCRIPTION
fixes #125 

不正なコマンド行に対応するために、パーサに以下の変更をしました：

- EOF をトークンとして扱う
- トークンを読み込むバッファ（`t_parse_buffer`）が空になったとき、自動的に標準入力に切り替えるのをやめて EOF を返す

`-c` オプションを使ったときの動作もこれで修正されました。
```
$ ./minishell -c 'echo "aho'
aho
$ ./minishell -c 'echo \'
\
```
