### PR TITLE
プロンプト表示と長い行の編集時の問題を修正

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,6 +42,8 @@ OBJS = $(SRCS:.c=.o)
 
 all: $(NAME)
 
+$(OBJS): $(HEADER_FILES)
+
 $(NAME): ${HEADER_FILES} ${OBJS}
 	$(LIBFT_MAKE)
 	$(CC) $(CFLAGS) -o $(NAME) $(OBJS) $(LDFLAGS)

--- a/editor.h
+++ b/editor.h
@@ -83,5 +83,6 @@ int		edit_setup_terminal(void);
 int		edit_handle_delete(
 			t_command_history *history, t_command_state *st, char ch);
 void	edit_handle_backspace(t_command_history *history, t_command_state *st);
+void	edit_redraw(t_command_history *history, t_command_state *st);
 
 #endif

--- a/editor.h
+++ b/editor.h
@@ -34,10 +34,13 @@ typedef struct s_term_controls
 	char	areabuf[64];
 	char	*c_cursor_left;
 	char	*c_cursor_right;
+	char	*c_cursor_up;
+	char	*c_cursor_down;
 	char	*c_clr_bol;
 	char	*c_enter_insert_mode;
 	char	*c_exit_insert_mode;
 	char	*c_delete_character;
+	char	*c_cursor_address;
 }	t_term_controls;
 
 typedef struct s_command_state

--- a/editor.h
+++ b/editor.h
@@ -37,6 +37,7 @@ typedef struct s_term_controls
 	char	*c_cursor_up;
 	char	*c_cursor_down;
 	char	*c_clr_bol;
+	char	*c_clr_eol;
 	char	*c_enter_insert_mode;
 	char	*c_exit_insert_mode;
 	char	*c_delete_character;

--- a/editor.h
+++ b/editor.h
@@ -71,7 +71,8 @@ void	edit_normal_character(
 			char *cbuf);
 void	edit_enter(t_command_history *history, t_command_state *st);
 void	edit_sig_catch(int signo);
-int		edit_handle_left_right(t_command_state *st, char c);
+int		edit_handle_left(t_command_state *st, char c);
+int		edit_handle_right(t_command_state *st, char c);
 int		edit_handle_up_down(
 			t_command_history *history, t_command_state *st, char c);
 void	edit_handle_escape_sequence(

--- a/editor.h
+++ b/editor.h
@@ -31,7 +31,7 @@ typedef struct s_command_history
 
 typedef struct s_term_controls
 {
-	char	areabuf[64];
+	char	areabuf[128];
 	char	*c_cursor_left;
 	char	*c_cursor_right;
 	char	*c_cursor_up;
@@ -41,6 +41,8 @@ typedef struct s_term_controls
 	char	*c_exit_insert_mode;
 	char	*c_delete_character;
 	char	*c_cursor_address;
+	char	*c_save_cursor;
+	char	*c_restore_cursor;
 }	t_term_controls;
 
 typedef struct s_command_state
@@ -58,7 +60,7 @@ void	edit_error_exit(const char *message);
 int		tty_set_attributes(int fd, struct termios *buf);
 int		tty_cbreak(int fd);
 void	edit_init_history(t_command_history *his);
-int		edit_print_history(t_command_history *his, int index);
+int		edit_print_history(t_command_history *his, int his_index, int index);
 void	edit_dump_history(t_command_history *his);
 void	edit_add_new_rope(t_command_history *history, char *cbuf);
 void	edit_insert_character(

--- a/editor1.c
+++ b/editor1.c
@@ -67,6 +67,7 @@ int	edit_read_execute(t_command_history *history, t_command_state *state)
 	t_parse_ast			*seqcmd;
 	t_parse_buffer		buf;
 
+	write(STDOUT_FILENO, MINISHELL_PROMPT, MINISHELL_PROMPT_LEN);
 	splay_init(&rope, edit_get_line(history, state));
 	if (rope)
 	{

--- a/editor1.c
+++ b/editor1.c
@@ -98,7 +98,6 @@ int	edit_main(void)
 	state.cursor_x = 0;
 	state.length = 0;
 	edit_term_controls_init(&state.cnt);
-	tputs(state.cnt.c_enter_insert_mode, 1, edit_putc);
 	running = 1;
 	while (running)
 		running = edit_read_execute(&history, &state);

--- a/editor2.c
+++ b/editor2.c
@@ -58,7 +58,7 @@ int	edit_handle_up_down(t_command_history *history, t_command_state *st, char c)
 		tputs(st->cnt.c_clr_bol, 1, edit_putc);
 		edit_putc('\r');
 		write(STDOUT_FILENO, MINISHELL_PROMPT, MINISHELL_PROMPT_LEN);
-		st->cursor_x = edit_print_history(history, history->current);
+		st->cursor_x = edit_print_history(history, history->current, 0);
 		st->length = st->cursor_x;
 	}
 	else if (c == 'A' && history->current != history->begin)
@@ -68,7 +68,7 @@ int	edit_handle_up_down(t_command_history *history, t_command_state *st, char c)
 		tputs(st->cnt.c_clr_bol, 1, edit_putc);
 		edit_putc('\r');
 		write(STDOUT_FILENO, MINISHELL_PROMPT, MINISHELL_PROMPT_LEN);
-		st->cursor_x = edit_print_history(history, history->current);
+		st->cursor_x = edit_print_history(history, history->current, 0);
 		st->length = st->cursor_x;
 	}
 	return (1);
@@ -118,6 +118,8 @@ void	edit_term_controls_init(t_term_controls *t)
 	t->c_enter_insert_mode = tgetstr("im", &area);
 	t->c_exit_insert_mode = tgetstr("ei", &area);
 	t->c_delete_character = tgetstr("dc", &area);
+	t->c_save_cursor = tgetstr("sc", &area);
+	t->c_restore_cursor = tgetstr("rc", &area);
 }
 
 int	edit_setup_terminal(void)

--- a/editor2.c
+++ b/editor2.c
@@ -6,48 +6,6 @@
 #include "parse.h"
 #include "minishell.h"
 
-#include <stdio.h>
-int	edit_handle_left_right(t_command_state *st, char c)
-{
-	if (c == 'D')
-	{
-		if (st->cursor_x > 0)
-		{
-			if ((st->cursor_x + MINISHELL_PROMPT_LEN) % tgetnum("co") > 0)
-				tputs(st->cnt.c_cursor_left, 1, edit_putc);
-			else
-			{
-				int	col;
-				tputs(st->cnt.c_cursor_up, 1, edit_putc);
-				col = tgetnum("co");
-				while (col-- > 1)
-					tputs(st->cnt.c_cursor_right, 1, edit_putc);
-			}
-			st->cursor_x--;
-		}
-		return (1);
-	}
-	else if (c == 'C')
-	{
-		if (st->cursor_x < st->length)
-		{
-			int	col;
-			col = tgetnum("co");
-			if ((st->cursor_x + MINISHELL_PROMPT_LEN) % tgetnum("co") < col - 1)
-				tputs(st->cnt.c_cursor_right, 1, edit_putc);
-			else
-			{
-				tputs(st->cnt.c_cursor_down, 1, edit_putc);
-				while (col-- > 1)
-					tputs(st->cnt.c_cursor_left, 1, edit_putc);
-			}
-			st->cursor_x++;
-		}
-		return (1);
-	}
-	return (0);
-}
-
 int	edit_handle_up_down(t_command_history *history, t_command_state *st, char c)
 {
 	if (c != 'A' && c != 'B')
@@ -87,7 +45,8 @@ void	edit_handle_escape_sequence(
 	i = read(STDIN_FILENO, cbuf, 1);
 	if (i != 1)
 		return ;
-	if (edit_handle_left_right(st, cbuf[0])
+	if (edit_handle_left(st, cbuf[0])
+		|| edit_handle_right(st, cbuf[0])
 		|| edit_handle_up_down(history, st, cbuf[0])
 		|| edit_handle_delete(history, st, cbuf[0]))
 		;

--- a/editor2.c
+++ b/editor2.c
@@ -74,6 +74,7 @@ void	edit_term_controls_init(t_term_controls *t)
 	t->c_cursor_up = tgetstr("up", &area);
 	t->c_cursor_down = tgetstr("do", &area);
 	t->c_clr_bol = tgetstr("cb", &area);
+	t->c_clr_eol = tgetstr("ce", &area);
 	t->c_enter_insert_mode = tgetstr("im", &area);
 	t->c_exit_insert_mode = tgetstr("ei", &area);
 	t->c_delete_character = tgetstr("dc", &area);

--- a/editor2.c
+++ b/editor2.c
@@ -52,24 +52,22 @@ int	edit_handle_up_down(t_command_history *history, t_command_state *st, char c)
 {
 	if (c != 'A' && c != 'B')
 		return (0);
-	if (c == 'B')
+	if (c == 'B' && history->current != history->end)
 	{
-		if (history->current != history->end)
-		{
-			history->current = (history->current + 1) % LINE_BUFFER_SIZE;
-			tputs(st->cnt.c_clr_bol, 1, edit_putc);
-			edit_putc('\r');
-			st->cursor_x = edit_print_history(history, history->current);
-			st->length = st->cursor_x;
-		}
-		return (1);
+		history->current = (history->current + 1) % LINE_BUFFER_SIZE;
+		tputs(st->cnt.c_clr_bol, 1, edit_putc);
+		edit_putc('\r');
+		write(STDOUT_FILENO, MINISHELL_PROMPT, MINISHELL_PROMPT_LEN);
+		st->cursor_x = edit_print_history(history, history->current);
+		st->length = st->cursor_x;
 	}
-	if (history->current != history->begin)
+	else if (c == 'A' && history->current != history->begin)
 	{
 		history->current = (LINE_BUFFER_SIZE + history->current - 1)
 			% LINE_BUFFER_SIZE;
 		tputs(st->cnt.c_clr_bol, 1, edit_putc);
 		edit_putc('\r');
+		write(STDOUT_FILENO, MINISHELL_PROMPT, MINISHELL_PROMPT_LEN);
 		st->cursor_x = edit_print_history(history, history->current);
 		st->length = st->cursor_x;
 	}

--- a/editor2.c
+++ b/editor2.c
@@ -9,10 +9,11 @@ int	edit_handle_left_right(t_command_state *st, char c)
 {
 	if (c == 'D')
 	{
-		tputs(st->cnt.c_cursor_left, 1, edit_putc);
-		st->cursor_x--;
-		if (st->cursor_x < 0)
-			st->cursor_x = 0;
+		if (st->cursor_x > 0)
+		{
+			tputs(st->cnt.c_cursor_left, 1, edit_putc);
+			st->cursor_x--;
+		}
 		return (1);
 	}
 	else if (c == 'C')

--- a/editor3.c
+++ b/editor3.c
@@ -1,4 +1,5 @@
 #include <stdio.h>
+#include "minishell.h"
 #include "editor.h"
 
 void	edit_dump_history(t_command_history *his)
@@ -11,7 +12,7 @@ void	edit_dump_history(t_command_history *his)
 	while (index != his->end)
 	{
 		printf("| '");
-		edit_print_history(his, index);
+		edit_print_history(his, index, 0);
 		printf("'\n");
 		index = (index + 1) % LINE_BUFFER_SIZE;
 	}
@@ -61,6 +62,9 @@ void	edit_normal_character(
 	t_command_history *history, t_command_state *st,
 	char *cbuf)
 {
+	int	col;
+
+	col = tgetnum("co");
 	if (cbuf[0] == 0x7f)
 	{
 		edit_handle_backspace(history, st);
@@ -73,6 +77,14 @@ void	edit_normal_character(
 		edit_insert_character(history, cbuf, st->cursor_x, st->length);
 	st->cursor_x++;
 	st->length++;
+	if ((st->cursor_x + MINISHELL_PROMPT_LEN) % col == 0)
+	{
+		tputs(st->cnt.c_cursor_down, 1, edit_putc);
+		write(1, "\r", 1);
+	}
+	tputs(st->cnt.c_save_cursor, 1, edit_putc);
+	edit_print_history(history, history->current, st->cursor_x);
+	tputs(st->cnt.c_restore_cursor, 1, edit_putc);
 }
 
 void	edit_enter(t_command_history *history, t_command_state *st)

--- a/editor3.c
+++ b/editor3.c
@@ -11,9 +11,9 @@ void	edit_dump_history(t_command_history *his)
 	index = his->begin;
 	while (index != his->end)
 	{
-		printf("| '");
+		write(1, "| '", 3);
 		edit_print_history(his, index, 0);
-		printf("'\n");
+		write(1, "'\n", 2);
 		index = (index + 1) % LINE_BUFFER_SIZE;
 	}
 }
@@ -82,13 +82,18 @@ void	edit_normal_character(
 		tputs(st->cnt.c_cursor_down, 1, edit_putc);
 		write(1, "\r", 1);
 	}
-	tputs(st->cnt.c_save_cursor, 1, edit_putc);
-	edit_print_history(history, history->current, st->cursor_x);
-	tputs(st->cnt.c_restore_cursor, 1, edit_putc);
+	edit_redraw(history, st);
 }
 
+/*
+ * This function is called when the Enter key is pressed to execute
+ * the given command.  Calling edit_print_history() to make sure the
+ * cursor is on the end of the line before the execution otherwise the
+ * output from the command may overwrite the current command line.
+ */
 void	edit_enter(t_command_history *history, t_command_state *st)
 {
+	edit_print_history(history, history->current, st->cursor_x);
 	history->current = history->end;
 	splay_release(history->ropes[history->current]);
 	history->ropes[history->current] = NULL;

--- a/editor4.c
+++ b/editor4.c
@@ -78,19 +78,19 @@ void	edit_init_history(t_command_history *his)
 		his->ropes[i++] = NULL;
 }
 
-int	edit_print_history(t_command_history *his, int index)
+int	edit_print_history(t_command_history *his, int his_index, int index)
 {
 	t_rope	*rope;
 	int		len;
 	int		i;
 	char	ch;
 
-	rope = his->ropes[index];
+	rope = his->ropes[his_index];
 	len = 0;
 	if (rope)
 	{
 		len = rope_length(rope);
-		i = 0;
+		i = index;
 		while (i < len)
 		{
 			ch = rope_index(rope, i);

--- a/editor5.c
+++ b/editor5.c
@@ -18,18 +18,11 @@ int	edit_putc(int ch)
 
 int	tty_reset(int fd)
 {
-	char	areabuf[32];
-	char	*area;
-	char	*c_exit_insert_mode;
-
-	area = areabuf;
-	c_exit_insert_mode = tgetstr("ei", &area);
 	if (g_term_stat.ttystate == TTY_RESET)
 		return (0);
 	if (tcsetattr(fd, TCSAFLUSH, &g_term_stat.save_termios) < 0)
 		return (-1);
 	g_term_stat.ttystate = TTY_RESET;
-	tputs(c_exit_insert_mode, 1, edit_putc);
 	return (0);
 }
 

--- a/editor5.c
+++ b/editor5.c
@@ -37,5 +37,6 @@ void	edit_redraw(t_command_history *history, t_command_state *st)
 {
 	tputs(st->cnt.c_save_cursor, 1, edit_putc);
 	edit_print_history(history, history->current, st->cursor_x);
+	tputs(st->cnt.c_clr_eol, 1, edit_putc);
 	tputs(st->cnt.c_restore_cursor, 1, edit_putc);
 }

--- a/editor5.c
+++ b/editor5.c
@@ -32,3 +32,10 @@ void	edit_sig_catch(int signo)
 	tty_reset(STDIN_FILENO);
 	exit(0);
 }
+
+void	edit_redraw(t_command_history *history, t_command_state *st)
+{
+	tputs(st->cnt.c_save_cursor, 1, edit_putc);
+	edit_print_history(history, history->current, st->cursor_x);
+	tputs(st->cnt.c_restore_cursor, 1, edit_putc);
+}

--- a/editor6.c
+++ b/editor6.c
@@ -13,6 +13,7 @@ static void	delete_char(t_command_history *history, t_command_state *st)
 		&history->ropes[history->current],
 		rope_delete(rope, st->cursor_x, st->cursor_x + 1));
 	splay_release(rope);
+	edit_redraw(history, st);
 }
 
 int	edit_handle_delete(

--- a/editor6.c
+++ b/editor6.c
@@ -1,4 +1,5 @@
 #include <unistd.h>
+#include "minishell.h"
 #include "editor.h"
 
 static void	delete_char(t_command_history *history, t_command_state *st)
@@ -44,4 +45,52 @@ void	edit_handle_backspace(t_command_history *history, t_command_state *st)
 	tputs(st->cnt.c_cursor_left, 1, edit_putc);
 	st->cursor_x--;
 	delete_char(history, st);
+}
+
+int	edit_handle_left(t_command_state *st, char c)
+{
+	int	col;
+
+	if (c == 'D')
+	{
+		if (st->cursor_x > 0)
+		{
+			if ((st->cursor_x + MINISHELL_PROMPT_LEN) % tgetnum("co") > 0)
+				tputs(st->cnt.c_cursor_left, 1, edit_putc);
+			else
+			{
+				tputs(st->cnt.c_cursor_up, 1, edit_putc);
+				col = tgetnum("co");
+				while (col-- > 1)
+					tputs(st->cnt.c_cursor_right, 1, edit_putc);
+			}
+			st->cursor_x--;
+		}
+		return (1);
+	}
+	return (0);
+}
+
+int	edit_handle_right(t_command_state *st, char c)
+{
+	int	col;
+
+	if (c == 'C')
+	{
+		if (st->cursor_x < st->length)
+		{
+			col = tgetnum("co");
+			if ((st->cursor_x + MINISHELL_PROMPT_LEN) % tgetnum("co") < col - 1)
+				tputs(st->cnt.c_cursor_right, 1, edit_putc);
+			else
+			{
+				tputs(st->cnt.c_cursor_down, 1, edit_putc);
+				while (col-- > 1)
+					tputs(st->cnt.c_cursor_left, 1, edit_putc);
+			}
+			st->cursor_x++;
+		}
+		return (1);
+	}
+	return (0);
 }

--- a/editor6.c
+++ b/editor6.c
@@ -43,11 +43,13 @@ void	edit_handle_backspace(t_command_history *history, t_command_state *st)
 {
 	if (st->cursor_x == 0)
 		return ;
-	tputs(st->cnt.c_cursor_left, 1, edit_putc);
-	st->cursor_x--;
+	edit_handle_left(st, 'D');
 	delete_char(history, st);
 }
 
+/*
+ * (The escape sequence for the left key is '^[[D'.)
+ */
 int	edit_handle_left(t_command_state *st, char c)
 {
 	int	col;

--- a/minishell.h
+++ b/minishell.h
@@ -6,7 +6,8 @@
 # include "parse.h"
 # include "env.h"
 
-# define PROMPT "minish > "
+# define MINISHELL_PROMPT "minish > "
+# define MINISHELL_PROMPT_LEN 9
 
 // グローバル構造体
 typedef struct s_shell {

--- a/signal.c
+++ b/signal.c
@@ -5,7 +5,7 @@
 
 static void	sigint_sighandler(int sig)
 {
-	ft_putstr_fd("\n\r"PROMPT, STDOUT_FILENO);
+	ft_putstr_fd("\n\r" MINISHELL_PROMPT, STDOUT_FILENO);
 	set_status(128 + sig);
 }
 


### PR DESCRIPTION
closes #118

長い行を入力して途中までカーソルを戻して編集したときに、画面の端にカーソルがあるとうまく動かなかったので修正しました。Termcap のいろんな機能をつかってかなり強引に動かしているので、なにか変な動きを見つけたらおしえてください。