### PR TITLE
Ctrl-D とシグナルハンドラの処理

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,8 @@ SRCS = cmd_cmd_invocation.c cmd_cmd_invocation2.c cmd_exec_command.c		\
 	rope1.c rope2.c rope3.c rope4.c splay1.c splay2.c splay3.c splay4.c		\
 	splay5.c splay6.c														\
 																			\
-	editor1.c editor2.c editor3.c editor4.c editor5.c editor6.c
+	editor1.c editor2.c editor3.c editor4.c editor5.c editor6.c				\
+	editor7.c
 
 OBJS = $(SRCS:.c=.o)
 

--- a/editor.h
+++ b/editor.h
@@ -19,7 +19,7 @@ typedef struct s_terminal_state
 	t_tty_state		ttystate;
 }	t_terminal_state;
 
-extern t_terminal_state	g_term_stat;
+/* extern t_terminal_state	g_term_stat; */
 
 typedef struct s_command_history
 {
@@ -85,5 +85,6 @@ int		edit_handle_delete(
 			t_command_history *history, t_command_state *st, char ch);
 void	edit_handle_backspace(t_command_history *history, t_command_state *st);
 void	edit_redraw(t_command_history *history, t_command_state *st);
+int	handle_ctrl_d(t_command_history *history, t_command_state *st);
 
 #endif

--- a/editor.h
+++ b/editor.h
@@ -88,5 +88,6 @@ void	edit_redraw(t_command_history *history, t_command_state *st);
 int		edit_handle_ctrl_d(t_command_history *history, t_command_state *st);
 void	edit_cleanup_history(t_command_history *history);
 void	edit_delete_char(t_command_history *history, t_command_state *st);
+t_rope	*edit_get_line(t_command_history *history, t_command_state *state);
 
 #endif

--- a/editor.h
+++ b/editor.h
@@ -85,6 +85,8 @@ int		edit_handle_delete(
 			t_command_history *history, t_command_state *st, char ch);
 void	edit_handle_backspace(t_command_history *history, t_command_state *st);
 void	edit_redraw(t_command_history *history, t_command_state *st);
-int	handle_ctrl_d(t_command_history *history, t_command_state *st);
+int		edit_handle_ctrl_d(t_command_history *history, t_command_state *st);
+void	edit_cleanup_history(t_command_history *history);
+void	edit_delete_char(t_command_history *history, t_command_state *st);
 
 #endif

--- a/editor1.c
+++ b/editor1.c
@@ -83,6 +83,7 @@ int	edit_main(void)
 	t_command_history	history;
 	t_command_state		state;
 
+	edit_terminal_state_init(&g_shell.term_stat);
 	edit_init_history(&history);
 	edit_setup_terminal();
 	state.cursor_x = 0;

--- a/editor1.c
+++ b/editor1.c
@@ -16,7 +16,6 @@ t_rope	*edit_get_line(t_command_history *history, t_command_state *state)
 	cbuf[1] = '\0';
 	while (1)
 	{
-		/* printf("%s: %d\n", __FUNCTION__, __LINE__); */
 		input_count = 0;
 		while (input_count == 0)
 		{
@@ -32,7 +31,6 @@ t_rope	*edit_get_line(t_command_history *history, t_command_state *state)
 		}
 		if (input_count != 1)
 			break ;
-		/* printf("%s: %d\n", __FUNCTION__, __LINE__); */
 		if (cbuf[0] >= 0x20)
 			edit_normal_character(history, state, cbuf);
 		else if (cbuf[0] == '\n')
@@ -124,7 +122,6 @@ int	edit_main(void)
 	t_command_history	history;
 	t_command_state		state;
 
-	/* edit_terminal_state_init(&g_term_stat); */
 	edit_init_history(&history);
 	edit_setup_terminal();
 	state.cursor_x = 0;

--- a/editor1.c
+++ b/editor1.c
@@ -25,9 +25,9 @@ t_rope	*edit_get_line(t_command_history *history, t_command_state *state)
 			{
 				g_shell.interrupted = 0;
 				splay_assign(&history->ropes[history->current], NULL);
-	splay_release(rope);
-	edit_putc('\n');
-	return (NULL);
+				splay_release(rope);
+				edit_putc('\n');
+				return (NULL);
 			}
 		}
 		if (input_count != 1)
@@ -43,7 +43,7 @@ t_rope	*edit_get_line(t_command_history *history, t_command_state *state)
 				rope->refcount--;
 			return (rope);
 		}
-		else if (cbuf[0] == 0x04 && !handle_ctrl_d(history, state))
+		else if (cbuf[0] == 0x04 && !edit_handle_ctrl_d(history, state))
 			break ;
 		else if (cbuf[0] == 0x1b)
 			if (read(STDIN_FILENO, cbuf, 1) == 1 && cbuf[0] == '[')
@@ -123,6 +123,7 @@ int	edit_main(void)
 	g_shell.running = 1;
 	while (g_shell.running)
 		edit_read_execute(&history, &state);
+	edit_cleanup_history(&history);
 	if (tty_reset(STDIN_FILENO) < 0)
 		edit_error_exit("tty_reset error");
 	return (0);

--- a/editor2.c
+++ b/editor2.c
@@ -89,12 +89,12 @@ int	edit_setup_terminal(void)
 	if (!term)
 		edit_error_exit("getenv(TERM) error");
 	tgetent(NULL, term);
-	if (signal(SIGINT, edit_sig_catch) == SIG_ERR)
-		edit_error_exit("signal(SIGINT) error");
-	if (signal(SIGQUIT, edit_sig_catch) == SIG_ERR)
-		edit_error_exit("signal(SIGQUIT) error");
-	if (signal(SIGTERM, edit_sig_catch) == SIG_ERR)
-		edit_error_exit("signal(SIGTERM) error");
+	/* if (signal(SIGINT, edit_sig_catch) == SIG_ERR) */
+	/* 	edit_error_exit("signal(SIGINT) error"); */
+	/* if (signal(SIGQUIT, edit_sig_catch) == SIG_ERR) */
+	/* 	edit_error_exit("signal(SIGQUIT) error"); */
+	/* if (signal(SIGTERM, edit_sig_catch) == SIG_ERR) */
+	/* 	edit_error_exit("signal(SIGTERM) error"); */
 	if (tty_cbreak(STDIN_FILENO) < 0)
 		edit_error_exit("tty_cbreak error");
 	return (1);

--- a/editor2.c
+++ b/editor2.c
@@ -89,12 +89,6 @@ int	edit_setup_terminal(void)
 	if (!term)
 		edit_error_exit("getenv(TERM) error");
 	tgetent(NULL, term);
-	/* if (signal(SIGINT, edit_sig_catch) == SIG_ERR) */
-	/* 	edit_error_exit("signal(SIGINT) error"); */
-	/* if (signal(SIGQUIT, edit_sig_catch) == SIG_ERR) */
-	/* 	edit_error_exit("signal(SIGQUIT) error"); */
-	/* if (signal(SIGTERM, edit_sig_catch) == SIG_ERR) */
-	/* 	edit_error_exit("signal(SIGTERM) error"); */
 	if (tty_cbreak(STDIN_FILENO) < 0)
 		edit_error_exit("tty_cbreak error");
 	return (1);

--- a/editor4.c
+++ b/editor4.c
@@ -4,6 +4,7 @@
 #include <string.h>
 #include "libft/libft.h"
 #include "editor.h"
+#include "minishell.h"
 
 void	edit_error_exit(const char *message)
 {
@@ -19,30 +20,34 @@ void	edit_error_exit(const char *message)
 	}
 	exit (1);
 }
-
+/* #include <stdio.h> */
 int	tty_set_attributes(int fd, struct termios *buf)
 {
 	int	err;
 
 	buf->c_lflag &= ~(ECHO | ICANON);
-	buf->c_cc[VMIN] = 1;
-	buf->c_cc[VTIME] = 0;
+	buf->c_cc[VMIN] = 0;
+	buf->c_cc[VTIME] = 1;
+	/* printf("%s: %d\n", __FUNCTION__, __LINE__); */
 	if (tcsetattr(fd, TCSAFLUSH, buf) < 0)
 		return (-1);
+	/* printf("%s: %d\n", __FUNCTION__, __LINE__); */
 	if (tcgetattr(fd, buf) < 0)
 	{
 		err = errno;
-		tcsetattr(fd, TCSAFLUSH, &g_term_stat.save_termios);
+		tcsetattr(fd, TCSAFLUSH, &g_shell.term_stat.save_termios);
 		errno = err;
 		return (-1);
 	}
-	if ((buf->c_lflag & (ECHO | ICANON)) || buf->c_cc[VMIN] != 1
-		|| buf->c_cc[VTIME] != 0)
+	/* printf("%s: %d\n", __FUNCTION__, __LINE__); */
+	if ((buf->c_lflag & (ECHO | ICANON)) || buf->c_cc[VMIN] != 0
+		|| buf->c_cc[VTIME] != 1)
 	{
-		tcsetattr(fd, TCSAFLUSH, &g_term_stat.save_termios);
+		tcsetattr(fd, TCSAFLUSH, &g_shell.term_stat.save_termios);
 		errno = EINVAL;
 		return (-1);
 	}
+	/* printf("%s: %d\n", __FUNCTION__, __LINE__); */
 	return (0);
 }
 
@@ -51,18 +56,24 @@ int	tty_cbreak(int fd)
 	int				err;
 	struct termios	buf;
 
-	if (g_term_stat.ttystate != TTY_RESET)
+	if (g_shell.term_stat.ttystate != TTY_RESET)
 	{
 		errno = EINVAL;
 		return (-1);
 	}
+	/* printf("%s, %d\n", __FUNCTION__, __LINE__); */
 	if (tcgetattr(fd, &buf) < 0)
 		return (-1);
-	g_term_stat.save_termios = buf;
+	/* printf("%s, %d\n", __FUNCTION__, __LINE__); */
+	g_shell.term_stat.save_termios = buf;
+	/* printf("%s, %d\n", __FUNCTION__, __LINE__); */
 	err = tty_set_attributes(fd, &buf);
+	/* printf("%s, %d\n", __FUNCTION__, __LINE__); */
 	if (err)
 		return (err);
-	g_term_stat.ttystate = TTY_CBREAK;
+	/* printf("%s, %d\n", __FUNCTION__, __LINE__); */
+	g_shell.term_stat.ttystate = TTY_CBREAK;
+	/* printf("%s, %d\n", __FUNCTION__, __LINE__); */
 	return (0);
 }
 

--- a/editor4.c
+++ b/editor4.c
@@ -20,7 +20,7 @@ void	edit_error_exit(const char *message)
 	}
 	exit (1);
 }
-/* #include <stdio.h> */
+
 int	tty_set_attributes(int fd, struct termios *buf)
 {
 	int	err;
@@ -28,10 +28,8 @@ int	tty_set_attributes(int fd, struct termios *buf)
 	buf->c_lflag &= ~(ECHO | ICANON);
 	buf->c_cc[VMIN] = 0;
 	buf->c_cc[VTIME] = 1;
-	/* printf("%s: %d\n", __FUNCTION__, __LINE__); */
 	if (tcsetattr(fd, TCSAFLUSH, buf) < 0)
 		return (-1);
-	/* printf("%s: %d\n", __FUNCTION__, __LINE__); */
 	if (tcgetattr(fd, buf) < 0)
 	{
 		err = errno;
@@ -39,7 +37,6 @@ int	tty_set_attributes(int fd, struct termios *buf)
 		errno = err;
 		return (-1);
 	}
-	/* printf("%s: %d\n", __FUNCTION__, __LINE__); */
 	if ((buf->c_lflag & (ECHO | ICANON)) || buf->c_cc[VMIN] != 0
 		|| buf->c_cc[VTIME] != 1)
 	{
@@ -47,7 +44,6 @@ int	tty_set_attributes(int fd, struct termios *buf)
 		errno = EINVAL;
 		return (-1);
 	}
-	/* printf("%s: %d\n", __FUNCTION__, __LINE__); */
 	return (0);
 }
 
@@ -61,19 +57,13 @@ int	tty_cbreak(int fd)
 		errno = EINVAL;
 		return (-1);
 	}
-	/* printf("%s, %d\n", __FUNCTION__, __LINE__); */
 	if (tcgetattr(fd, &buf) < 0)
 		return (-1);
-	/* printf("%s, %d\n", __FUNCTION__, __LINE__); */
 	g_shell.term_stat.save_termios = buf;
-	/* printf("%s, %d\n", __FUNCTION__, __LINE__); */
 	err = tty_set_attributes(fd, &buf);
-	/* printf("%s, %d\n", __FUNCTION__, __LINE__); */
 	if (err)
 		return (err);
-	/* printf("%s, %d\n", __FUNCTION__, __LINE__); */
 	g_shell.term_stat.ttystate = TTY_CBREAK;
-	/* printf("%s, %d\n", __FUNCTION__, __LINE__); */
 	return (0);
 }
 

--- a/editor5.c
+++ b/editor5.c
@@ -25,13 +25,6 @@ int	tty_reset(int fd)
 	return (0);
 }
 
-/* void	edit_sig_catch(int signo) */
-/* { */
-/* 	printf("signal caught %d\n", signo); */
-/* 	tty_reset(STDIN_FILENO); */
-/* 	exit(0); */
-/* } */
-
 void	edit_redraw(t_command_history *history, t_command_state *st)
 {
 	tputs(st->cnt.c_save_cursor, 1, edit_putc);

--- a/editor5.c
+++ b/editor5.c
@@ -2,8 +2,7 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include "editor.h"
-
-t_terminal_state	g_term_stat;
+#include "minishell.h"
 
 void	edit_terminal_state_init(t_terminal_state *st)
 {
@@ -18,20 +17,20 @@ int	edit_putc(int ch)
 
 int	tty_reset(int fd)
 {
-	if (g_term_stat.ttystate == TTY_RESET)
+	if (g_shell.term_stat.ttystate == TTY_RESET)
 		return (0);
-	if (tcsetattr(fd, TCSAFLUSH, &g_term_stat.save_termios) < 0)
+	if (tcsetattr(fd, TCSAFLUSH, &g_shell.term_stat.save_termios) < 0)
 		return (-1);
-	g_term_stat.ttystate = TTY_RESET;
+	g_shell.term_stat.ttystate = TTY_RESET;
 	return (0);
 }
 
-void	edit_sig_catch(int signo)
-{
-	printf("signal caught %d\n", signo);
-	tty_reset(STDIN_FILENO);
-	exit(0);
-}
+/* void	edit_sig_catch(int signo) */
+/* { */
+/* 	printf("signal caught %d\n", signo); */
+/* 	tty_reset(STDIN_FILENO); */
+/* 	exit(0); */
+/* } */
 
 void	edit_redraw(t_command_history *history, t_command_state *st)
 {

--- a/editor6.c
+++ b/editor6.c
@@ -2,7 +2,7 @@
 #include "minishell.h"
 #include "editor.h"
 
-static void	delete_char(t_command_history *history, t_command_state *st)
+void	edit_delete_char(t_command_history *history, t_command_state *st)
 {
 	t_rope	*rope;
 
@@ -34,7 +34,7 @@ int	edit_handle_delete(
 	if (!rope)
 		return (1);
 	if (st->cursor_x < rope_length(rope))
-		delete_char(history, st);
+		edit_delete_char(history, st);
 	splay_release(rope);
 	return (1);
 }
@@ -44,7 +44,7 @@ void	edit_handle_backspace(t_command_history *history, t_command_state *st)
 	if (st->cursor_x == 0)
 		return ;
 	edit_handle_left(st, 'D');
-	delete_char(history, st);
+	edit_delete_char(history, st);
 }
 
 /*

--- a/editor7.c
+++ b/editor7.c
@@ -1,15 +1,27 @@
 #include "editor.h"
 #include "minishell.h"
 
-int	handle_ctrl_d(t_command_history *history, t_command_state *st)
+int	edit_handle_ctrl_d(t_command_history *history, t_command_state *st)
 {
 	t_rope	*rope;
 
 	splay_init(&rope, history->ropes[history->current]);
 	if (rope_length(rope) == 0)
+	{
 		g_shell.running = 0;
+		write(1, "exit\n", 5);
+	}
 	else
-		edit_handle_delete(history, st, '3');
+		edit_delete_char(history, st);
 	splay_release(rope);
 	return (g_shell.running);
+}
+
+void	edit_cleanup_history(t_command_history *history)
+{
+	int	i;
+
+	i = 0;
+	while (i < LINE_BUFFER_SIZE)
+		splay_assign(&history->ropes[i++], NULL);
 }

--- a/editor7.c
+++ b/editor7.c
@@ -1,6 +1,56 @@
 #include "editor.h"
 #include "minishell.h"
 
+static int	edit_read_char(
+		t_command_history *history, t_command_state *state, char *cbuf)
+{
+	int	input_count;
+
+	input_count = 0;
+	while (input_count == 0)
+	{
+		input_count = read(STDIN_FILENO, cbuf, 1);
+		if (g_shell.interrupted)
+		{
+			g_shell.interrupted = 0;
+			splay_assign(&history->ropes[history->current], NULL);
+			state->length = 0;
+			state->cursor_x = 0;
+			edit_putc('\n');
+			input_count = -1;
+		}
+	}
+	return (input_count);
+}
+
+t_rope	*edit_get_line(t_command_history *history, t_command_state *state)
+{
+	char	cbuf[2];
+	t_rope	*rope;
+
+	cbuf[1] = '\0';
+	while (1)
+	{
+		if (edit_read_char(history, state, cbuf) != 1
+			|| (cbuf[0] == 0x04 && !edit_handle_ctrl_d(history, state)))
+			break ;
+		if (cbuf[0] == '\n')
+		{
+			splay_init(&rope, history->ropes[history->current]);
+			edit_enter(history, state);
+			if (rope)
+				rope->refcount--;
+			return (rope);
+		}
+		if (cbuf[0] >= 0x20)
+			edit_normal_character(history, state, cbuf);
+		else if (cbuf[0] == 0x1b)
+			if (read(STDIN_FILENO, cbuf, 1) == 1 && cbuf[0] == '[')
+				edit_handle_escape_sequence (history, state);
+	}
+	return (NULL);
+}
+
 int	edit_handle_ctrl_d(t_command_history *history, t_command_state *st)
 {
 	t_rope	*rope;

--- a/editor7.c
+++ b/editor7.c
@@ -54,14 +54,16 @@ t_rope	*edit_get_line(t_command_history *history, t_command_state *state)
 int	edit_handle_ctrl_d(t_command_history *history, t_command_state *st)
 {
 	t_rope	*rope;
+	int		len;
 
 	splay_init(&rope, history->ropes[history->current]);
-	if (rope_length(rope) == 0)
+	len = rope_length(rope);
+	if (len == 0)
 	{
 		g_shell.running = 0;
 		write(1, "exit\n", 5);
 	}
-	else
+	else if (st->cursor_x < len)
 		edit_delete_char(history, st);
 	splay_release(rope);
 	return (g_shell.running);

--- a/editor7.c
+++ b/editor7.c
@@ -1,0 +1,15 @@
+#include "editor.h"
+#include "minishell.h"
+
+int	handle_ctrl_d(t_command_history *history, t_command_state *st)
+{
+	t_rope	*rope;
+
+	splay_init(&rope, history->ropes[history->current]);
+	if (rope_length(rope) == 0)
+		g_shell.running = 0;
+	else
+		edit_handle_delete(history, st, '3');
+	splay_release(rope);
+	return (g_shell.running);
+}

--- a/minishell.h
+++ b/minishell.h
@@ -17,6 +17,7 @@ typedef struct s_shell {
 	int					interrupted;
 	t_terminal_state	term_stat;
 	int					running;
+	int					signal_child_received;
 }				t_shell;
 extern t_shell	g_shell;
 
@@ -39,6 +40,7 @@ char					**expand_string_node(t_parse_node_string *string_node);
 char					**split_expanded_str(char *str);
 char					**expand_string_node(t_parse_node_string *string_node);
 void					set_shell_sighandlers(void);
+void					set_sighandlers_during_execution(void);
 void					set_sighandlers(t_sighandler sighandler);
 void					put_minish_err_msg(const char *cmd_name,
 							const char *msg);

--- a/minishell.h
+++ b/minishell.h
@@ -5,14 +5,18 @@
 # include "execution.h"
 # include "parse.h"
 # include "env.h"
+# include "editor.h"
 
 # define MINISHELL_PROMPT "minish > "
 # define MINISHELL_PROMPT_LEN 9
 
 typedef struct s_shell {
-	char		*cwd;
-	t_var		*vars;
-	int			status;
+	char				*cwd;
+	t_var				*vars;
+	int					status;
+	int					interrupted;
+	t_terminal_state	term_stat;
+	int					running;
 }				t_shell;
 extern t_shell	g_shell;
 

--- a/shell_initialization.c
+++ b/shell_initialization.c
@@ -72,7 +72,6 @@ void	init_g_shell(void)
 	g_shell.vars = environ2vars(environ);
 	g_shell.status = 0;
 	g_shell.interrupted = 0;
-	edit_terminal_state_init(&g_shell.term_stat);
 }
 
 int	initialize_shell(void)

--- a/shell_initialization.c
+++ b/shell_initialization.c
@@ -1,6 +1,7 @@
 #include <unistd.h>
 #include "minishell.h"
 #include "env.h"
+#include "editor.h"
 #include "libft/libft.h"
 
 static void	init_pwd(void)
@@ -70,6 +71,8 @@ void	init_g_shell(void)
 	g_shell.cwd = NULL;
 	g_shell.vars = environ2vars(environ);
 	g_shell.status = 0;
+	g_shell.interrupted = 0;
+	edit_terminal_state_init(&g_shell.term_stat);
 }
 
 int	initialize_shell(void)

--- a/shell_initialization.c
+++ b/shell_initialization.c
@@ -78,7 +78,6 @@ void	init_g_shell(void)
 int	initialize_shell(void)
 {
 	init_g_shell();
-	set_shell_sighandlers();
 	init_pwd();
 	init_shlvl();
 	return (0);

--- a/signal.c
+++ b/signal.c
@@ -2,10 +2,13 @@
 #include <stdio.h>
 #include "minishell.h"
 #include "env.h"
+#include "editor.h"
 
 static void	sigint_sighandler(int sig)
 {
-	ft_putstr_fd("\n\r" MINISHELL_PROMPT, STDOUT_FILENO);
+	/* ft_putstr_fd("\n\r" MINISHELL_PROMPT, STDOUT_FILENO); */
+	/* printf("INTERRUPTED\n"); */
+	g_shell.interrupted = 1;
 	set_status(128 + sig);
 }
 
@@ -20,6 +23,7 @@ void	set_sighandlers(t_sighandler sighandler)
 	if (signal(SIGQUIT, sighandler) == SIG_ERR
 		|| signal(SIGINT, sighandler) == SIG_ERR)
 	{
+		tty_reset(STDIN_FILENO);
 		printf("signal() failed\n");
 		exit(1);
 	}

--- a/signal.c
+++ b/signal.c
@@ -8,15 +8,16 @@ static void	sigint_sighandler(int sig)
 {
 	/* ft_putstr_fd("\n\r" MINISHELL_PROMPT, STDOUT_FILENO); */
 	/* printf("INTERRUPTED\n"); */
+	write(STDOUT_FILENO, "^C", 2);
 	g_shell.interrupted = 1;
 	set_status(128 + sig);
 }
 
-static void	sigquit_sighandler(int sig)
-{
-	(void)sig;
-	ft_putstr_fd("\b\b  \b\b", STDOUT_FILENO);
-}
+/* static void	sigquit_sighandler(int sig) */
+/* { */
+/* 	(void)sig; */
+/* 	/\* ft_putstr_fd("\b\b  \b\b", STDOUT_FILENO); *\/ */
+/* } */
 
 void	set_sighandlers(t_sighandler sighandler)
 {
@@ -34,12 +35,28 @@ void	set_sighandlers(t_sighandler sighandler)
  *
  * This function set these signal handlers.
  * - SIGQUIT: Ignore signal. Do nothing.
- * - SIGINT: Line break and show prompt.
+ * - SIGINT: Show "^C"
  */
 void	set_shell_sighandlers(void)
 {
-	if (signal(SIGQUIT, sigquit_sighandler) == SIG_ERR
+	if (signal(SIGQUIT, SIG_IGN) == SIG_ERR
 		|| signal(SIGINT, sigint_sighandler) == SIG_ERR)
+	{
+		printf("signal() failed\n");
+		exit(1);
+	}
+}
+
+static void	sighandler_during_execution(int sig)
+{
+	g_shell.signal_child_received = sig;
+}
+
+void	set_sighandlers_during_execution(void)
+{
+	g_shell.signal_child_received = 0;
+	if (signal(SIGQUIT, sighandler_during_execution) == SIG_ERR
+		|| signal(SIGINT, sighandler_during_execution) == SIG_ERR)
 	{
 		printf("signal() failed\n");
 		exit(1);

--- a/signal.c
+++ b/signal.c
@@ -6,18 +6,10 @@
 
 static void	sigint_sighandler(int sig)
 {
-	/* ft_putstr_fd("\n\r" MINISHELL_PROMPT, STDOUT_FILENO); */
-	/* printf("INTERRUPTED\n"); */
 	write(STDOUT_FILENO, "^C", 2);
 	g_shell.interrupted = 1;
 	set_status(128 + sig);
 }
-
-/* static void	sigquit_sighandler(int sig) */
-/* { */
-/* 	(void)sig; */
-/* 	/\* ft_putstr_fd("\b\b  \b\b", STDOUT_FILENO); *\/ */
-/* } */
 
 void	set_sighandlers(t_sighandler sighandler)
 {
@@ -35,7 +27,7 @@ void	set_sighandlers(t_sighandler sighandler)
  *
  * This function set these signal handlers.
  * - SIGQUIT: Ignore signal. Do nothing.
- * - SIGINT: Show "^C"
+ * - SIGINT: Show "^C" since echo is disabled on the terminal.
  */
 void	set_shell_sighandlers(void)
 {

--- a/signal.c
+++ b/signal.c
@@ -16,7 +16,6 @@ void	set_sighandlers(t_sighandler sighandler)
 	if (signal(SIGQUIT, sighandler) == SIG_ERR
 		|| signal(SIGINT, sighandler) == SIG_ERR)
 	{
-		tty_reset(STDIN_FILENO);
 		printf("signal() failed\n");
 		exit(1);
 	}

--- a/test/Makefile
+++ b/test/Makefile
@@ -1,18 +1,28 @@
 LIBFT_PATH = ../libft
 LIBFT_MAKE = $(MAKE) -C $(LIBFT_PATH)
 LIBFT_LIB = ../libft/libft.a
-SRCS = 	../env.c ../env_setter.c ../path.c ../g_cwd.c												\
-		../lexer1.c ../lexer2.c ../lexer3.c															\
-		../parse1.c ../parse2.c ../parse_utils.c ../parse_utils2.c									\
-		../exec.c ../cmd_exec_command.c ../cmd_exec_commands.c ../cmd_redirection.c ../cmd_pipe.c	\
-		../cmd_cmd_invocation.c ../cmd_cmd_invocation2.c ../convert_ast2cmdinvo.c					\
-		../expand_env_var.c ../split_expanded_str.c ../string_node2string.c ../expand_string_node.c	\
-		../cmd_status.c ../signal.c ../cmd_status.c ../signal.c ../minishell_error_msg.c			\
-		../builtin.c ../builtin_echo.c ../builtin_env.c												\
-		../builtin_cd.c ../builtin_cd_path.c ../builtin_cd_chdir.c ../builtin_cd_cdpath.c			\
-		../builtin_exit.c ../builtin_export.c ../builtin_export2.c ../builtin_pwd.c ../builtin_unset.c					\
-		../str_utils.c ../shell_initialization.c ../cmd_exec_builtin.c \
-		../t_var.c ../t_var2.c
+SRCFILES = cmd_cmd_invocation.c cmd_cmd_invocation2.c cmd_exec_command.c	\
+	cmd_exec_commands.c cmd_pipe.c cmd_redirection.c convert_ast2cmdinvo.c	\
+	cmd_status.c signal.c env_setter.c minishell_error_msg.c env.c exec.c	\
+	cmd_exec_builtin.c														\
+																			\
+	lexer1.c lexer2.c lexer3.c parse1.c parse2.c parse_utils.c				\
+	parse_utils2.c															\
+																			\
+	path.c g_cwd.c string_node2string.c expand_env_var.c					\
+	expand_string_node.c split_expanded_str.c t_var.c t_var2.c				\
+																			\
+	builtin.c builtin_echo.c builtin_env.c builtin_exit.c builtin_cd.c		\
+	builtin_cd_path.c builtin_cd_chdir.c builtin_cd_cdpath.c				\
+	builtin_export.c builtin_export2.c builtin_pwd.c builtin_unset.c		\
+																			\
+	str_utils.c shell_initialization.c										\
+																			\
+	rope1.c rope2.c rope3.c rope4.c splay1.c splay2.c splay3.c splay4.c		\
+	splay5.c splay6.c
+
+SRCS = $(patsubst %,../%,$(SRCFILES))
+
 HEADERS = ../env.h \
 		  ../parse.h \
 		  ../execution.h \
@@ -77,5 +87,7 @@ fclean:
 	rm -f ./exec_test
 	rm -f ./command_exec_test
 	rm -f ./ast2cmdinvo_test
+	rm -f ./rope_test
+	rm -f ./splay_test
 
 re: fclean run


### PR DESCRIPTION
Closes #111 

- コマンドラインで Ctrl-D を押したときに、すでに文字が入力されていれば DEL と同じふるまいをし、そうでなければ exit する。
- コマンド実行中に SIGINT や SIGQUIT などのシグナルを受け取ったときは、次のプロンプトを表示する前に改行を出力する
  - （そうしないと表示が崩れる）
- コマンド実行前にターミナルの設定をリセットし、コマンド実行後にまた設定し直す