### PR TITLE
履歴を編集するときはコピーオンライトで新しい履歴を追加する。

### DIFF
--- a/editor.h
+++ b/editor.h
@@ -51,6 +51,7 @@ typedef struct s_command_state
 	int				cursor_x;
 	int				length;
 	t_term_controls	cnt;
+	int				current_history_index;
 }	t_command_state;
 
 int		edit_main(void);
@@ -89,5 +90,6 @@ int		edit_handle_ctrl_d(t_command_history *history, t_command_state *st);
 void	edit_cleanup_history(t_command_history *history);
 void	edit_delete_char(t_command_history *history, t_command_state *st);
 t_rope	*edit_get_line(t_command_history *history, t_command_state *state);
+void	edit_copy_history_if_needed(t_command_history *history);
 
 #endif

--- a/editor.h
+++ b/editor.h
@@ -81,6 +81,7 @@ void	edit_handle_escape_sequence(
 			t_command_history *history, t_command_state *st);
 void	edit_term_controls_init(t_term_controls *t);
 int		edit_setup_terminal(void);
+void	edit_adjust_history_index(t_command_history *history);
 
 int		edit_handle_delete(
 			t_command_history *history, t_command_state *st, char ch);
@@ -90,6 +91,7 @@ int		edit_handle_ctrl_d(t_command_history *history, t_command_state *st);
 void	edit_cleanup_history(t_command_history *history);
 void	edit_delete_char(t_command_history *history, t_command_state *st);
 t_rope	*edit_get_line(t_command_history *history, t_command_state *state);
-void	edit_copy_history_if_needed(t_command_history *history);
+void	edit_copy_history_if_needed(
+			t_command_history *history, t_command_state *state);
 
 #endif

--- a/editor1.c
+++ b/editor1.c
@@ -57,6 +57,7 @@ int	edit_read_and_execute(t_command_history *history, t_command_state *state)
 	t_parse_ast			*cmdline;
 	t_parse_buffer		buf;
 
+	state->current_history_index = history->current;
 	set_shell_sighandlers();
 	write(STDOUT_FILENO, MINISHELL_PROMPT, MINISHELL_PROMPT_LEN);
 	splay_init(&rope, edit_get_line(history, state));

--- a/editor2.c
+++ b/editor2.c
@@ -93,3 +93,13 @@ int	edit_setup_terminal(void)
 		edit_error_exit("tty_cbreak error");
 	return (1);
 }
+
+void	edit_adjust_history_index(t_command_history *history)
+{
+	if (history->current == history->end)
+	{
+		history->end = (history->end + 1) % LINE_BUFFER_SIZE;
+		if (history->end == history->begin)
+			history->begin = (history->end + 1) % LINE_BUFFER_SIZE;
+	}
+}

--- a/editor2.c
+++ b/editor2.c
@@ -10,7 +10,7 @@ int	edit_handle_up_down(t_command_history *history, t_command_state *st, char c)
 {
 	if (c != 'A' && c != 'B')
 		return (0);
-	if (c == 'B' && history->current != history->end)
+	if (c == 'B' && history->current != st->current_history_index)
 	{
 		history->current = (history->current + 1) % LINE_BUFFER_SIZE;
 		tputs(st->cnt.c_clr_bol, 1, edit_putc);

--- a/editor3.c
+++ b/editor3.c
@@ -20,12 +20,7 @@ void	edit_dump_history(t_command_history *his)
 
 void	edit_add_new_rope(t_command_history *history, char *cbuf)
 {
-	if (history->current == history->end)
-	{
-		history->end = (history->end + 1) % LINE_BUFFER_SIZE;
-		if (history->end == history->begin)
-			history->begin = (history->end + 1) % LINE_BUFFER_SIZE;
-	}
+	edit_adjust_history_index(history);
 	splay_assign(
 		&history->ropes[history->current], rope_create(cbuf, NULL));
 }
@@ -64,6 +59,7 @@ void	edit_normal_character(
 {
 	int	col;
 
+	edit_copy_history_if_needed(history, st);
 	col = tgetnum("co");
 	if (cbuf[0] == 0x7f)
 	{

--- a/editor6.c
+++ b/editor6.c
@@ -8,7 +8,7 @@ void	edit_delete_char(t_command_history *history, t_command_state *st)
 
 	edit_copy_history_if_needed(history, st);
 	splay_init(&rope, history->ropes[history->current]);
-	tputs(st->cnt.c_delete_character, 1, edit_putc);
+	/* tputs(st->cnt.c_delete_character, 1, edit_putc); */
 	st->length--;
 	splay_assign(
 		&history->ropes[history->current],

--- a/editor6.c
+++ b/editor6.c
@@ -8,7 +8,6 @@ void	edit_delete_char(t_command_history *history, t_command_state *st)
 
 	edit_copy_history_if_needed(history, st);
 	splay_init(&rope, history->ropes[history->current]);
-	/* tputs(st->cnt.c_delete_character, 1, edit_putc); */
 	st->length--;
 	splay_assign(
 		&history->ropes[history->current],

--- a/editor6.c
+++ b/editor6.c
@@ -6,6 +6,7 @@ void	edit_delete_char(t_command_history *history, t_command_state *st)
 {
 	t_rope	*rope;
 
+	edit_copy_history_if_needed(history, st);
 	splay_init(&rope, history->ropes[history->current]);
 	tputs(st->cnt.c_delete_character, 1, edit_putc);
 	st->length--;

--- a/editor7.c
+++ b/editor7.c
@@ -77,3 +77,33 @@ void	edit_cleanup_history(t_command_history *history)
 	while (i < LINE_BUFFER_SIZE)
 		splay_assign(&history->ropes[i++], NULL);
 }
+
+void	edit_copy_history_if_needed(
+			t_command_history *history, t_command_state *st)
+{
+	t_rope	*new_rope;
+	t_rope	*rope;
+	int		len;
+	char	buf[2];
+
+	if (history->current != st->current_history_index)
+	{
+		buf[1] = '\0';
+		splay_init(&rope, history->ropes[history->current]);
+		len = rope_length(rope);
+		new_rope = NULL;
+		while (len > 0)
+		{
+			buf[0] = rope_index(rope, len - 1);
+			splay_assign(
+				&new_rope, rope_concat(
+					rope_create(buf, NULL), new_rope));
+			len--;
+		}
+		splay_assign(&history->ropes[st->current_history_index], new_rope);
+		splay_release(rope);
+		splay_release(new_rope);
+		history->current = st->current_history_index;
+		edit_adjust_history_index(history);
+	}
+}


### PR DESCRIPTION
Fixes #119

これまで、↑キーを押して過去のコマンドを表示した状態でそのコマンドを編集すると、履歴の項目そのものが更新されてしまい、Subject の要件に合わなかった。

この PR では、過去の履歴の項目に対して何らかの更新が行われようとした場合に、自動的に履歴の項目をコピーし、そのコピーに対して更新をするように変更した。

### 変更前
![Peek 2021-06-06 14-13](https://user-images.githubusercontent.com/65044/120913346-692db600-c6d1-11eb-8050-86f533ec11ee.gif)

### 変更後
![Peek 2021-06-06 14-11](https://user-images.githubusercontent.com/65044/120913349-6b901000-c6d1-11eb-97de-2ea604ce581a.gif)
