### PR TITLE
Rope の操作でたまに文字列が壊れるのを修正。

### DIFF
--- a/rope1.c
+++ b/rope1.c
@@ -27,7 +27,27 @@ t_rope	*rope_create(char *left, char *right)
 
 t_rope	*rope_concat(t_rope *left, t_rope *right)
 {
-	return (splay_create(left, ROPE_NOWEIGHT, right));
+	t_rope	*l;
+	t_rope	*r;
+	t_rope	*result;
+
+	if (!left && !right)
+		return (NULL);
+	splay_init(&l, left);
+	splay_init(&r, right);
+	if (l && !l->right && l->left)
+		splay_assign(&l, l->left);
+	else if (l && l->right && !l->left)
+		splay_assign(&l, l->right);
+	if (r && !r->right && r->left)
+		splay_assign(&r, r->left);
+	else if (r && r->right && !r->left)
+		splay_assign(&r, r->right);
+	splay_init(&result, splay_create(l, ROPE_NOWEIGHT, r));
+	splay_release(l);
+	splay_release(r);
+	result->refcount--;
+	return (result);
 }
 
 int	rope_weight(t_rope *rope)

--- a/test/rope_test.c
+++ b/test/rope_test.c
@@ -314,6 +314,179 @@ void	test_rope()
 		splay_release(rope);
 	}
 
+	TEST_SECTION("rope_split 右に偏った木");
+	{
+		t_rope	*rope;
+
+		splay_init(&rope,
+				   rope_concat(
+					   rope_create("0", NULL),
+					   rope_concat(
+						   rope_create("1", NULL),
+						   rope_concat(
+							   rope_create("2", NULL),
+							   rope_concat(
+								   rope_create("3", NULL),
+								   NULL)))));
+
+		CHECK_EQ(rope_length(rope), 4);
+
+		t_rope	*left = NULL, *right = NULL;
+		rope_split(rope, 2, &left, &right);
+		CHECK_EQ(rope_length(left), 2);
+		CHECK_EQ(rope_length(right), 2);
+
+		splay_release(left);
+		splay_release(right);
+		splay_release(rope);
+	}
+
+	TEST_SECTION("rope_split 右に偏った 3 要素の木の最後の要素");
+	{
+		t_rope	*rope;
+
+		splay_init(&rope,
+				   rope_concat(
+					   rope_create("0", NULL),
+					   rope_concat(
+						   rope_create("1", NULL),
+						   rope_concat(
+							   rope_create("2", NULL),
+							   NULL))));
+
+		CHECK_EQ(rope_length(rope), 3);
+
+		t_splay_path	*path = NULL;
+		rope_index_with_path(rope, 2, &path);
+
+		CHECK_EQ_STR((char*)&path->node->value, "2");
+		CHECK_EQ(path->dir, SPLAY_RIGHT);
+		CHECK_EQ(path->next->dir, SPLAY_RIGHT);
+		CHECK_EQ(path->next->next->dir, SPLAY_ROOT);
+		CHECK_EQ_STR((char*)&path->next->node->left->value, "1");
+		splay_path_release(path);
+
+		t_rope	*left = NULL, *right = NULL;
+		rope_split(rope, 2, &left, &right);
+		CHECK_EQ(rope_length(left), 2);
+		CHECK_EQ(rope_length(right), 1);
+
+		splay_release(left);
+		splay_release(right);
+		splay_release(rope);
+	}
+
+	TEST_SECTION("rope_split 右に偏った木の最後の要素");
+	{
+		t_rope	*rope;
+
+		splay_init(&rope,
+				   rope_concat(
+					   rope_create("0", NULL),
+					   rope_concat(
+						   rope_create("1", NULL),
+						   rope_concat(
+							   rope_create("2", NULL),
+							   rope_concat(
+								   rope_create("3", NULL),
+								   NULL)))));
+
+		CHECK_EQ(rope_length(rope), 4);
+
+		t_rope	*left = NULL, *right = NULL;
+		rope_split(rope, 3, &left, &right);
+		CHECK_EQ(rope_length(left), 3);
+		CHECK_EQ(rope_length(right), 1);
+
+		splay_release(left);
+		splay_release(right);
+		splay_release(rope);
+	}
+
+	TEST_SECTION("rope_delete 右に偏った木");
+	{
+		t_rope	*rope;
+
+		splay_init(&rope,
+				   rope_concat(
+					   rope_create("0", NULL),
+					   rope_concat(
+						   rope_create("1", NULL),
+						   rope_concat(
+							   rope_create("2", NULL),
+							   rope_concat(
+								   rope_create("3", NULL),
+								   NULL)))));
+
+		CHECK_EQ(rope_length(rope), 4);
+
+		splay_assign(&rope, rope_delete(rope, 2, 3));
+		CHECK_EQ(rope_length(rope), 3);
+
+		splay_release(rope);
+	}
+
+	TEST_SECTION("rope_split 左に偏った木");
+	{
+		t_rope	*rope;
+
+		splay_init(&rope,
+				   rope_concat(
+					   rope_concat(
+						   rope_concat(
+							   NULL,
+							   rope_create("0", NULL)),
+						   rope_create("1", NULL)),
+					   rope_create("2", NULL)));
+
+		CHECK_EQ(rope_length(rope), 3);
+
+		t_rope	*left = NULL, *right = NULL;
+		rope_split(rope, 2, &left, &right);
+		CHECK_EQ(rope_length(left), 2);
+		CHECK_EQ_STR((char*)&left->left->value, "0");
+		CHECK_EQ_STR((char*)&left->right->value, "1");
+		CHECK_EQ(rope_length(right), 1);
+		CHECK_EQ_STR((char*)&right->value, "2");
+
+		t_rope	*lleft = NULL, *lright = NULL;
+		rope_split(left, 1, &lleft, &lright);
+		CHECK_EQ(rope_length(lleft), 1);
+		CHECK_EQ_STR((char*)&lleft->value, "0");
+		CHECK_EQ(rope_length(lright), 1);
+		CHECK_EQ_STR((char*)&lright->value, "1");
+		splay_release(lleft);
+		splay_release(lright);
+
+		splay_release(left);
+		splay_release(right);
+
+		splay_release(rope);
+	}
+
+	TEST_SECTION("rope_delete 左に偏った木");
+	{
+		t_rope	*rope;
+
+		splay_init(&rope,
+				   rope_concat(
+					   rope_concat(
+						   rope_concat(
+							   NULL,
+							   rope_create("0", NULL)),
+						   rope_create("1", NULL)),
+					   rope_create("2", NULL)));
+
+		CHECK_EQ(rope_length(rope), 3);
+
+		splay_assign(&rope, rope_delete(rope, 1, 2));
+		CHECK_EQ(rope_length(rope), 2);
+		CHECK_EQ_STR((char*)&rope->left->value, "0");
+		CHECK_EQ_STR((char*)&rope->right->value, "2");
+
+		splay_release(rope);
+	}
+
 }
 
 int main()

--- a/test/test.h
+++ b/test/test.h
@@ -6,12 +6,23 @@
 #include <stdbool.h>
 
 #define CHECK(val) test_check((int64_t)val, #val)
-#define CHECK_EQ(actual, expected) test_check(actual == expected, #actual " == " #expected)
-#define CHECK_EQ_STR(actual, expected) \
-  do { \
-	if (!test_check(strcmp(actual, expected) == 0, #actual " == " #expected)) \
-		printf("    |%s| == |%s|\n", actual, expected); \
-  } while(0)
+#define CHECK_EQ(actual, expected)								\
+	do {														\
+		if (!test_check(										\
+				actual == expected,								\
+				#actual " == " #expected))						\
+			printf("      actual: %lld\n    expected: %lld\n",	\
+				   (long long)actual, (long long)expected);		\
+	} while(0)
+
+#define CHECK_EQ_STR(actual, expected)						\
+	do {													\
+		if (!test_check(									\
+				strcmp(actual, expected) == 0,				\
+				#actual " == " #expected))					\
+			printf("    |%s| == |%s|\n", actual, expected);	\
+	} while(0)
+
 #define TEST_CHAPTER(message) printf("#\n# " message "\n#\n")
 #define TEST_SECTION(message) printf("- " message "\n")
 


### PR DESCRIPTION
Rope にたいしてスプレー操作をする結果、両方の子が NULL なのに文字列を持たないノードができてしまう事があった。この PR で Rope のノードを作る部分を修正し、両方の子が NULL になることがないようにした。

バグの再現画面
![Peek 2021-06-06 14-18](https://user-images.githubusercontent.com/65044/120954408-16640500-c78a-11eb-8629-559e8db3e9f4.gif)
