### PR TITLE
セミコロンで終わるコマンド行でエラーにならないように修正。 

### DIFF
--- a/parse.h
+++ b/parse.h
@@ -83,7 +83,6 @@ typedef struct s_parse_node_seqcmds
 typedef struct s_parse_node_cmdline
 {
 	t_parse_ast	*seqcmd_node;
-	t_parse_ast	*delimiter_node;
 }	t_parse_node_cmdline;
 
 typedef struct s_parse_ast

--- a/parse1.c
+++ b/parse1.c
@@ -4,7 +4,6 @@
 /*
 **command_line ::=
 **		"\n"
-**	  | sequential_commands delimiter "\n"
 **	  | sequential_commands "\n"
 */
 
@@ -13,20 +12,17 @@ t_parse_ast	*parse_command_line(
 {
 	t_parse_ast				*cmdline_node;
 	t_parse_ast				*seqcmd_node;
-	t_parse_ast				*delim_node;
 	t_parse_node_cmdline	*content_node;
 
 	seqcmd_node = parse_sequential_commands(buf, tok);
 	if (!seqcmd_node)
 		return (NULL);
-	delim_node = parse_delimiter(buf, tok);
 	parse_skip_spaces(buf, tok);
 	if (tok->type != TOKTYPE_NEWLINE)
 		return (NULL);
 	content_node = malloc(sizeof(t_parse_node_cmdline));
 	cmdline_node = parse_new_ast_node(ASTNODE_COMMAND_LINE, content_node);
 	content_node->seqcmd_node = seqcmd_node;
-	content_node->delimiter_node = delim_node;
 	return (cmdline_node);
 }
 
@@ -52,9 +48,9 @@ t_parse_ast	*parse_delimiter(
 }
 
 /*
-** FIXME: this rule doesn't handle the "piped_commands delimiter \n" case.
 **sequential_commands ::=
 **		piped_commands delimiter sequential_commands
+**	  | piped_commands delimiter
 **	  | piped_commands
 **	  | (bonus) piped_commands "&&" sequential_commands
 **	  | (bonus) piped_commands "||" sequential_commands
@@ -81,8 +77,6 @@ t_parse_ast	*parse_sequential_commands(
 		lex_get_token(buf, tok);
 		parse_skip_spaces(buf, tok);
 		content->rest_node = parse_sequential_commands(buf, tok);
-		if (!content->rest_node)
-			return (NULL);
 	}
 	return (seq_node);
 }

--- a/test/parse_test.c
+++ b/test/parse_test.c
@@ -913,7 +913,6 @@ void test_parser(void)
 		t_parse_ast *node = parse_command_line(&buf, &tok);
 
 		check_piped_seqence(node->content.command_line->seqcmd_node);
-		/* CHECK_EQ(node->content.command_line->delimiter_node, NULL); */
 	}
 
 	TEST_SECTION("parse_command_line バックスラッシュで終わる");


### PR DESCRIPTION
fixes #28 

command line の定義から delimiter を削除し sequential_commands で吸収します。