### PR TITLE
長い行に対応。

### DIFF
--- a/lexer2.c
+++ b/lexer2.c
@@ -22,12 +22,14 @@ int	lex_read_word(t_parse_buffer *buf, t_token *result)
 		ch = lex_getc(buf);
 		if (ch == EOF)
 			break ;
-		if (ch == '\\' || lex_is_special_char(ch))
+		if (ch == '\\' || lex_is_special_char(ch) || (ch == '$' && pos > 0))
 		{
 			lex_ungetc(buf);
 			break ;
 		}
 		result->text[pos++] = ch;
+		if (pos == PARSE_BUFFER_SIZE)
+			break;
 	}
 	result->length = pos;
 	return (1);

--- a/lexer2.c
+++ b/lexer2.c
@@ -29,7 +29,7 @@ int	lex_read_word(t_parse_buffer *buf, t_token *result)
 		}
 		result->text[pos++] = ch;
 		if (pos == PARSE_BUFFER_SIZE)
-			break;
+			break ;
 	}
 	result->length = pos;
 	return (1);
@@ -50,11 +50,14 @@ int	lex_read_double_quoted(t_parse_buffer *buf, t_token *result)
 			buf->lex_stat = LEXSTAT_NORMAL;
 		if (ch == '\n' || ch == EOF)
 			result->type = TOKTYPE_PARSE_ERROR;
-		if (ch == '\\' || ch == '\n' || ch == EOF)
+		if (ch == '\\' || ch == '\n' || ch == EOF || (ch == '$' && pos > 0))
 			lex_ungetc(buf);
-		if (ch == '\\' || ch == '"' || ch == '\n' || ch == EOF)
+		if (ch == '\\' || ch == '"' || ch == '\n' || ch == EOF
+			|| (ch == '$' && pos > 0))
 			break ;
 		result->text[pos++] = ch;
+		if (pos == PARSE_BUFFER_SIZE)
+			break ;
 	}
 	result->length = pos;
 	return (1);
@@ -79,6 +82,8 @@ int	lex_read_single_quoted(t_parse_buffer *buf, t_token *result)
 		if (ch == '\'' || ch == '\n' || ch == EOF)
 			break ;
 		result->text[pos++] = ch;
+		if (pos == PARSE_BUFFER_SIZE)
+			break ;
 	}
 	result->length = pos;
 	return (1);

--- a/parse.h
+++ b/parse.h
@@ -11,7 +11,7 @@ typedef void				t_lexer_ungetc(struct s_parse_buffer *buf);
 
 typedef struct s_parse_buffer
 {
-	char			buffer[PARSE_BUFFER_SIZE];
+	char			buffer[PARSE_BUFFER_SIZE * 100];
 	int				size;
 	int				cur_pos;
 	t_lexer_state	lex_stat;

--- a/test/ast2cmdinvo_test.c
+++ b/test/ast2cmdinvo_test.c
@@ -261,7 +261,9 @@ int main()
 		args_node = args_node->rest_node->content.arguments;
 		t_parse_node_string *string_node = args_node->string_node->content.string;
 		CHECK_EQ(string_node->type, TOKTYPE_EXPANDABLE);
-		CHECK_EQ_STR(string_node->text, "hoge$ABC");
+		CHECK_EQ_STR(string_node->text, "hoge");
+		string_node = string_node->next->content.string;
+		CHECK_EQ_STR(string_node->text, "$ABC");
 		string_node = string_node->next->content.string;
 		CHECK_EQ(string_node->type, TOKTYPE_EXPANDABLE_QUOTED);
 		CHECK_EQ_STR(string_node->text, "hoge hoge");
@@ -295,7 +297,9 @@ int main()
 
 		t_parse_node_string *string_node = args_node->string_node->content.string;
 		CHECK_EQ(string_node->type, TOKTYPE_EXPANDABLE);
-		CHECK_EQ_STR(string_node->text, "hoge$ABC");
+		CHECK_EQ_STR(string_node->text, "hoge");
+		string_node = string_node->next->content.string;
+		CHECK_EQ_STR(string_node->text, "$ABC");
 
 		string_node = string_node->next->content.string;
 		CHECK_EQ(string_node->type, TOKTYPE_EXPANDABLE_QUOTED);
@@ -907,7 +911,10 @@ int main()
 		CHECK_EQ_STR(args_node->string_node->content.string->text, "echo");
 		args_node = args_node->rest_node->content.arguments;
 		CHECK_EQ(args_node->string_node->content.string->type, TOKTYPE_EXPANDABLE);
-		CHECK_EQ_STR(args_node->string_node->content.string->text, "hoge$ABC");
+		t_parse_node_string *string_node = args_node->string_node->content.string;
+		CHECK_EQ_STR(string_node->text, "hoge");
+		string_node = string_node->next->content.string;
+		CHECK_EQ_STR(string_node->text, "$ABC");
 
 		/* テスト */
 		t_command_invocation *actual = cmd_ast_cmd2cmdinvo(node->content.command);
@@ -978,7 +985,12 @@ int main()
 		CHECK_EQ_STR(args_node->string_node->content.string->text, "echo");
 		args_node = args_node->rest_node->content.arguments;
 		CHECK_EQ(args_node->string_node->content.string->type, TOKTYPE_EXPANDABLE);
-		CHECK_EQ_STR(args_node->string_node->content.string->text, "$ABC$DEF");
+
+		t_parse_node_string *string_node = args_node->string_node->content.string;
+
+		CHECK_EQ_STR(string_node->text, "$ABC");
+		string_node = string_node->next->content.string;
+		CHECK_EQ_STR(string_node->text, "$DEF");
 
 		/* テスト */
 		t_command_invocation *actual = cmd_ast_cmd2cmdinvo(node->content.command);
@@ -1048,7 +1060,13 @@ int main()
 		CHECK_EQ_STR(args_node->string_node->content.string->text, "hello");
 		args_node = args_node->rest_node->content.arguments;
 		CHECK_EQ(args_node->redirection_node->content.redirection->type, TOKTYPE_OUTPUT_REDIRECTION);
-		CHECK_EQ_STR(args_node->redirection_node->content.redirection->string_node->content.string->text, "hoge$ABC");
+
+		t_parse_node_string *string_node =
+			args_node->redirection_node->content.redirection
+			->string_node->content.string;
+		CHECK_EQ_STR(string_node->text, "hoge");
+		string_node = string_node->next->content.string;
+		CHECK_EQ_STR(string_node->text, "$ABC");
 
 		/* テスト */
 		t_command_invocation *actual = cmd_ast_cmd2cmdinvo(node->content.command);

--- a/test/parse_test.c
+++ b/test/parse_test.c
@@ -999,6 +999,64 @@ void test_parser(void)
 		t_parse_ast *node = parse_command_line(&buf, &tok);
 		CHECK(!node);
 	}
+
+#define T8 "abcdefgh"
+#define T16 T8 T8
+#define T32 T16 T16
+#define T64 T32 T32
+#define T128 T64 T64
+#define T896 T128 T128 T128 T128 T128 T128 T128
+#define T1016 T896 T64 T32 T16 T8
+#define T1024 T896 T128
+#define T1280 T1024 T128 T128
+
+	TEST_SECTION("parse_command_line 長い行");
+	{
+		t_parse_buffer	buf;
+		init_buf_with_string(&buf, T1280 "\n");
+		t_token	tok;
+
+		lex_get_token(&buf, &tok);
+		t_parse_ast *node = parse_command_line(&buf, &tok);
+		CHECK(node);
+		node = node->content.command_line->seqcmd_node;
+		check_single_argument(
+			node->content.sequential_commands
+			->pipcmd_node->content.piped_commands
+			->command_node->content.command
+			->arguments_node,
+			T1024);
+	}
+
+	TEST_SECTION("parse_command_line 長い行の最後に変数");
+	{
+		t_parse_buffer	buf;
+		init_buf_with_string(&buf, T1016 "$deadbeef\n");
+		t_token	tok;
+
+		CHECK_EQ(strlen(T1016 "$deadbeef"), 1025);
+
+		lex_get_token(&buf, &tok);
+		CHECK_EQ(tok.length, 1016);
+		t_parse_ast *node = parse_command_line(&buf, &tok);
+		CHECK(node);
+		node = node->content.command_line->seqcmd_node
+			->content.sequential_commands
+			->pipcmd_node->content.piped_commands
+			->command_node->content.command
+			->arguments_node;
+		CHECK_EQ(node->type, ASTNODE_ARGUMENTS);
+		check_single_argument(node, T1016);
+		CHECK_EQ(
+			node->content.arguments
+			->string_node->content.string
+			->next->type, ASTNODE_STRING);
+		check_string(
+			node->content.arguments
+			->string_node->content.string
+			->next,
+			"$deadbeef");
+	}
 }
 
 int main()

--- a/test/test.h
+++ b/test/test.h
@@ -11,8 +11,11 @@
 		if (!test_check(										\
 				actual == expected,								\
 				#actual " == " #expected))						\
-			printf("      actual: %lld\n    expected: %lld\n",	\
-				   (long long)actual, (long long)expected);		\
+			printf(												\
+				"      actual: %lld\t%llx\n"					\
+				"    expected: %lld\t%llx\n",					\
+				   (long long)actual, (long long)actual,		\
+				   (long long)expected, (long long)expected);	\
 	} while(0)
 
 #define CHECK_EQ_STR(actual, expected)						\


### PR DESCRIPTION
これまで 1024 文字以上のトークンを入力するとパーサが壊れてしまっていたので、念の為それ以上のトークンも扱えるように修正しました。主な変更点は以下のとおりです：

- 長いトークンは 1024 文字で区切る
- `$` を見つけたらその直前で区切る

この変更にともなって、ast2cmdinvo_test も変更しました。

なお、この変更後も 1023 文字以上の環境変数は正しく扱えないけど、そこは諦めます。