### PR TITLE
リダイレクションとパイプの構文エラーの検出。

### DIFF
--- a/parse.h
+++ b/parse.h
@@ -88,6 +88,7 @@ typedef struct s_parse_node_cmdline
 typedef struct s_parse_ast
 {
 	t_parse_ast_type	type;
+	int					error;
 	union u_parse_ast_node_content
 	{
 		void						*void_ptr;

--- a/parse1.c
+++ b/parse1.c
@@ -6,7 +6,7 @@
 **		"\n"
 **	  | sequential_commands "\n"
 */
-
+#include <stdio.h>
 t_parse_ast	*parse_command_line(
 	t_parse_buffer *buf, t_token *tok)
 {
@@ -23,6 +23,10 @@ t_parse_ast	*parse_command_line(
 	content_node = malloc(sizeof(t_parse_node_cmdline));
 	cmdline_node = parse_new_ast_node(ASTNODE_COMMAND_LINE, content_node);
 	content_node->seqcmd_node = seqcmd_node;
+	cmdline_node->error = cmdline_node->error || seqcmd_node->error;
+	printf("%s: error: %d\n", __FUNCTION__, cmdline_node->error);
+	if (cmdline_node->error)
+		return (NULL);
 	return (cmdline_node);
 }
 
@@ -78,5 +82,9 @@ t_parse_ast	*parse_sequential_commands(
 		parse_skip_spaces(buf, tok);
 		content->rest_node = parse_sequential_commands(buf, tok);
 	}
+	seq_node->error = seq_node->error || pipcmd_node->error;
+	if (content->rest_node)
+		seq_node->error = seq_node->error || content->rest_node->error;
+	printf("%s: error: %d\n", __FUNCTION__, seq_node->error);
 	return (seq_node);
 }

--- a/parse1.c
+++ b/parse1.c
@@ -6,7 +6,7 @@
 **		"\n"
 **	  | sequential_commands "\n"
 */
-#include <stdio.h>
+
 t_parse_ast	*parse_command_line(
 	t_parse_buffer *buf, t_token *tok)
 {
@@ -24,7 +24,6 @@ t_parse_ast	*parse_command_line(
 	cmdline_node = parse_new_ast_node(ASTNODE_COMMAND_LINE, content_node);
 	content_node->seqcmd_node = seqcmd_node;
 	cmdline_node->error = cmdline_node->error || seqcmd_node->error;
-	printf("%s: error: %d\n", __FUNCTION__, cmdline_node->error);
 	if (cmdline_node->error)
 		return (NULL);
 	return (cmdline_node);
@@ -85,6 +84,5 @@ t_parse_ast	*parse_sequential_commands(
 	seq_node->error = seq_node->error || pipcmd_node->error;
 	if (content->rest_node)
 		seq_node->error = seq_node->error || content->rest_node->error;
-	printf("%s: error: %d\n", __FUNCTION__, seq_node->error);
 	return (seq_node);
 }

--- a/parse2.c
+++ b/parse2.c
@@ -7,7 +7,7 @@
 **		command "|" piped_commands
 **	  | command
 */
-
+#include <stdio.h>
 t_parse_ast	*parse_piped_commands(t_parse_buffer *buf, t_token *tok)
 {
 	t_parse_ast				*pip_node;
@@ -28,10 +28,15 @@ t_parse_ast	*parse_piped_commands(t_parse_buffer *buf, t_token *tok)
 		lex_get_token(buf, tok);
 		parse_skip_spaces(buf, tok);
 		rest_node = parse_piped_commands(buf, tok);
-		if (!rest_node)
-			return (NULL);
+		pip_node->error = pip_node->error || !!!rest_node;
+		/* if (!rest_node) */
+		/* 	return (NULL); */
 	}
 	content_node->next = rest_node;
+	pip_node->error = pip_node->error || cmd_node->error;
+	if (rest_node)
+		pip_node->error = pip_node->error || rest_node->error;
+	printf("%s: error: %d\n", __FUNCTION__, pip_node->error);
 	return (pip_node);
 }
 
@@ -54,6 +59,8 @@ t_parse_ast	*parse_command(t_parse_buffer *buf, t_token *tok)
 	content_node = malloc(sizeof(t_parse_node_command));
 	cmd_node = parse_new_ast_node(ASTNODE_COMMAND, content_node);
 	content_node->arguments_node = args_node;
+	cmd_node->error = cmd_node->error || args_node->error;
+	printf("%s: error: %d\n", __FUNCTION__, cmd_node->error);
 	return (cmd_node);
 }
 
@@ -85,6 +92,13 @@ t_parse_ast	*parse_arguments(t_parse_buffer *buf, t_token *tok)
 	content_node->string_node = string_node;
 	content_node->redirection_node = redirection_node;
 	content_node->rest_node = rest_node;
+	if (redirection_node)
+		args_node->error = args_node->error || redirection_node->error;
+	if (string_node)
+		args_node->error = args_node->error || string_node->error;
+	if (rest_node)
+		args_node->error = args_node->error || rest_node->error;
+	printf("%s: error: %d\n", __FUNCTION__, args_node->error);
 	return (args_node);
 }
 
@@ -147,14 +161,16 @@ t_parse_ast	*parse_redirection(
 	lex_get_token(buf, tok);
 	parse_skip_spaces(buf, tok);
 	str_node = parse_string(buf, tok);
-	if (str_node)
-	{
+	/* if (str_node) */
+	/* { */
 		redirection = malloc(sizeof(t_parse_node_redirection));
 		redirection->type = type;
 		redirection->fd = fd;
 		redirection->string_node = str_node;
 		new_node = parse_new_ast_node(ASTNODE_REDIRECTION, redirection);
+		new_node->error = (!!!str_node) || str_node->error;
+		printf("%s: error: %d\n", __FUNCTION__, new_node->error);
 		return (new_node);
-	}
-	return (NULL);
+	/* } */
+	/* return (NULL); */
 }

--- a/parse2.c
+++ b/parse2.c
@@ -7,7 +7,7 @@
 **		command "|" piped_commands
 **	  | command
 */
-#include <stdio.h>
+
 t_parse_ast	*parse_piped_commands(t_parse_buffer *buf, t_token *tok)
 {
 	t_parse_ast				*pip_node;
@@ -29,14 +29,11 @@ t_parse_ast	*parse_piped_commands(t_parse_buffer *buf, t_token *tok)
 		parse_skip_spaces(buf, tok);
 		rest_node = parse_piped_commands(buf, tok);
 		pip_node->error = pip_node->error || !!!rest_node;
-		/* if (!rest_node) */
-		/* 	return (NULL); */
 	}
 	content_node->next = rest_node;
 	pip_node->error = pip_node->error || cmd_node->error;
 	if (rest_node)
 		pip_node->error = pip_node->error || rest_node->error;
-	printf("%s: error: %d\n", __FUNCTION__, pip_node->error);
 	return (pip_node);
 }
 
@@ -60,7 +57,6 @@ t_parse_ast	*parse_command(t_parse_buffer *buf, t_token *tok)
 	cmd_node = parse_new_ast_node(ASTNODE_COMMAND, content_node);
 	content_node->arguments_node = args_node;
 	cmd_node->error = cmd_node->error || args_node->error;
-	printf("%s: error: %d\n", __FUNCTION__, cmd_node->error);
 	return (cmd_node);
 }
 
@@ -98,7 +94,6 @@ t_parse_ast	*parse_arguments(t_parse_buffer *buf, t_token *tok)
 		args_node->error = args_node->error || string_node->error;
 	if (rest_node)
 		args_node->error = args_node->error || rest_node->error;
-	printf("%s: error: %d\n", __FUNCTION__, args_node->error);
 	return (args_node);
 }
 
@@ -161,16 +156,11 @@ t_parse_ast	*parse_redirection(
 	lex_get_token(buf, tok);
 	parse_skip_spaces(buf, tok);
 	str_node = parse_string(buf, tok);
-	/* if (str_node) */
-	/* { */
-		redirection = malloc(sizeof(t_parse_node_redirection));
-		redirection->type = type;
-		redirection->fd = fd;
-		redirection->string_node = str_node;
-		new_node = parse_new_ast_node(ASTNODE_REDIRECTION, redirection);
-		new_node->error = (!!!str_node) || str_node->error;
-		printf("%s: error: %d\n", __FUNCTION__, new_node->error);
-		return (new_node);
-	/* } */
-	/* return (NULL); */
+	redirection = malloc(sizeof(t_parse_node_redirection));
+	redirection->type = type;
+	redirection->fd = fd;
+	redirection->string_node = str_node;
+	new_node = parse_new_ast_node(ASTNODE_REDIRECTION, redirection);
+	new_node->error = (!!!str_node) || str_node->error;
+	return (new_node);
 }

--- a/parse_utils2.c
+++ b/parse_utils2.c
@@ -47,6 +47,7 @@ t_parse_ast	*parse_new_ast_node(t_parse_ast_type type, void *content)
 	if (!content)
 		parse_fatal_error();
 	list = create_ast_on_list();
+	list->ast.error = 0;
 	list->ast.type = type;
 	list->ast.content.void_ptr = content;
 	return (&list->ast);

--- a/test/parse_test.c
+++ b/test/parse_test.c
@@ -1152,6 +1152,52 @@ void test_parser(void)
 		CHECK_EQ(node->content.string->type, TOKTYPE_NON_EXPANDABLE);
 		check_string(node, T128 T128); /* 256 */
 	}
+
+	TEST_SECTION("parse_command_line > のあとにファイル名が続かないときはエラー");
+	{
+		t_parse_buffer	buf;
+		init_buf_with_string(&buf, "aho >\n");
+		t_token	tok;
+
+		lex_get_token(&buf, &tok);
+		t_parse_ast *node = parse_command_line(&buf, &tok);
+		CHECK(!node);
+	}
+
+	TEST_SECTION("parse_command_line > のあとに ; はエラー");
+	{
+		t_parse_buffer	buf;
+		init_buf_with_string(&buf, "aho >; boke\n");
+		t_token	tok;
+
+		lex_get_token(&buf, &tok);
+		t_parse_ast *node = parse_command_line(&buf, &tok);
+		CHECK(!node);
+	}
+
+	TEST_SECTION("parse_command_line | のあとにコマンドが続かないときはエラー");
+	{
+		t_parse_buffer	buf;
+		init_buf_with_string(&buf, "aho |\n");
+		t_token	tok;
+
+		lex_get_token(&buf, &tok);
+		t_parse_ast *node = parse_command_line(&buf, &tok);
+		CHECK(!node);
+	}
+
+	TEST_SECTION("parse_command_line | のあとに ; はエラー");
+	{
+		t_parse_buffer	buf;
+		init_buf_with_string(&buf, "aho |; boke\n");
+		t_token	tok;
+
+		lex_get_token(&buf, &tok);
+		t_parse_ast *node = parse_command_line(&buf, &tok);
+		CHECK(!node);
+	}
+
+
 }
 
 int main()


### PR DESCRIPTION
fixes #132

AST にエラーのフラグを追加して、子要素にエラーがある場合は親に伝搬するようにしました。
これを使って、リダイレクト先のファイル名が指定されてない場合とパイプ先のコマンドが書かれていない場合にコマンドラインのパース結果を NULL にしています。