### PR TITLE
長い環境変数名でも正しく値に置き換えることができる

### DIFF
--- a/editor1.c
+++ b/editor1.c
@@ -69,6 +69,7 @@ int	edit_read_and_execute(t_command_history *history, t_command_state *state)
 	lex_get_token(&buf, &tok);
 	cmdline = parse_command_line(&buf, &tok);
 	splay_release(rope);
+	free(tok.text);
 	if (!cmdline)
 	{
 		put_err_msg("Parse error.");
@@ -77,7 +78,6 @@ int	edit_read_and_execute(t_command_history *history, t_command_state *state)
 	}
 	edit_execute(cmdline);
 	parse_free_all_ast();
-	free(tok.text);
 	return (1);
 }
 

--- a/editor1.c
+++ b/editor1.c
@@ -73,11 +73,9 @@ int	edit_read_and_execute(t_command_history *history, t_command_state *state)
 	if (!cmdline)
 	{
 		put_err_msg("Parse error.");
-		set_status(1);
-		return (1);
+		return (set_status_and_ret(1, 1));
 	}
 	edit_execute(cmdline);
-	parse_free_all_ast();
 	return (1);
 }
 
@@ -94,7 +92,10 @@ int	edit_main(void)
 	edit_term_controls_init(&state.cnt);
 	g_shell.running = 1;
 	while (g_shell.running)
+	{
 		edit_read_and_execute(&history, &state);
+		parse_free_all_ast();
+	}
 	edit_cleanup_history(&history);
 	if (tty_reset(STDIN_FILENO) < 0)
 		edit_error_exit("tty_reset error");

--- a/editor1.c
+++ b/editor1.c
@@ -65,6 +65,7 @@ int	edit_read_and_execute(t_command_history *history, t_command_state *state)
 		return (1);
 	splay_assign(&rope, rope_concat(rope, rope_create("\n", NULL)));
 	edit_init_parse_buffer_with_rope(&buf, rope);
+	lex_init_token(&tok);
 	lex_get_token(&buf, &tok);
 	cmdline = parse_command_line(&buf, &tok);
 	splay_release(rope);
@@ -76,6 +77,7 @@ int	edit_read_and_execute(t_command_history *history, t_command_state *state)
 	}
 	edit_execute(cmdline);
 	parse_free_all_ast();
+	free(tok.text);
 	return (1);
 }
 

--- a/lexer.h
+++ b/lexer.h
@@ -1,8 +1,6 @@
 #ifndef LEXER_H
 # define LEXER_H
 
-# define TOKEN_BUFFER_SIZE 1024
-
 typedef struct s_parse_buffer	t_parse_buffer;
 
 typedef enum e_token_type

--- a/lexer.h
+++ b/lexer.h
@@ -30,11 +30,14 @@ typedef enum e_lexer_state
 
 typedef struct s_token
 {
-	char			text[TOKEN_BUFFER_SIZE];
+	char			*text;
 	int				length;
+	int				max_length;
 	t_token_type	type;
 }	t_token;
 
+int		lex_init_token(t_token *result);
+int		lex_expand_text_buf(t_token *result);
 int		lex_getc(t_parse_buffer *buf);
 void	lex_ungetc(t_parse_buffer *buf);
 int		lex_is_special_char(char ch);

--- a/lexer2.c
+++ b/lexer2.c
@@ -28,8 +28,8 @@ int	lex_read_word(t_parse_buffer *buf, t_token *result)
 			break ;
 		}
 		result->text[pos++] = ch;
-		if (pos == PARSE_BUFFER_SIZE)
-			break ;
+		if (pos == result->max_length)
+			lex_expand_text_buf(result);
 	}
 	result->length = pos;
 	return (1);
@@ -56,8 +56,8 @@ int	lex_read_double_quoted(t_parse_buffer *buf, t_token *result)
 			|| (ch == '$' && pos > 0))
 			break ;
 		result->text[pos++] = ch;
-		if (pos == PARSE_BUFFER_SIZE)
-			break ;
+		if (pos == result->max_length)
+			lex_expand_text_buf(result);
 	}
 	result->length = pos;
 	return (1);
@@ -82,8 +82,8 @@ int	lex_read_single_quoted(t_parse_buffer *buf, t_token *result)
 		if (ch == '\'' || ch == '\n' || ch == EOF)
 			break ;
 		result->text[pos++] = ch;
-		if (pos == PARSE_BUFFER_SIZE)
-			break ;
+		if (pos == result->max_length)
+			lex_expand_text_buf(result);
 	}
 	result->length = pos;
 	return (1);

--- a/lexer3.c
+++ b/lexer3.c
@@ -68,7 +68,7 @@ int	lex_get_eof(t_token *result, int ch)
 
 int	lex_init_token(t_token *result)
 {
-	result->max_length = 8;
+	result->max_length = 1024;
 	result->text = malloc(result->max_length);
 	if (!result->text)
 	{

--- a/lexer3.c
+++ b/lexer3.c
@@ -65,3 +65,33 @@ int	lex_get_eof(t_token *result, int ch)
 	}
 	return (0);
 }
+
+int	lex_init_token(t_token *result)
+{
+	result->max_length = 1024;
+	result->text = malloc(result->max_length);
+	if (!result->text)
+	{
+		printf("malloc token buffer failed\n");
+		exit(1);
+	}
+	result->length = 0;
+	return (0);
+}
+
+int	lex_expand_text_buf(t_token *result)
+{
+	char	*old_text;
+
+	result->max_length *= 2;
+	old_text = result->text;
+	result->text = malloc(result->max_length);
+	if (!result->text)
+	{
+		printf("expand token buffer failed\n");
+		exit(1);
+	}
+	ft_memcpy(result->text, old_text, result->length);
+	free(old_text);
+	return (0);
+}

--- a/lexer3.c
+++ b/lexer3.c
@@ -84,15 +84,15 @@ int	lex_expand_text_buf(t_token *result)
 {
 	char	*old_text;
 
-	result->max_length *= 2;
 	old_text = result->text;
-	result->text = malloc(result->max_length);
+	result->text = malloc(result->max_length * 2);
 	if (!result->text)
 	{
 		printf("expand token buffer failed\n");
 		exit(1);
 	}
-	ft_memcpy(result->text, old_text, result->length);
+	ft_memcpy(result->text, old_text, result->max_length);
+	result->max_length = result->max_length * 2;
 	free(old_text);
 	return (0);
 }

--- a/lexer3.c
+++ b/lexer3.c
@@ -68,7 +68,7 @@ int	lex_get_eof(t_token *result, int ch)
 
 int	lex_init_token(t_token *result)
 {
-	result->max_length = 1024;
+	result->max_length = 8;
 	result->text = malloc(result->max_length);
 	if (!result->text)
 	{
@@ -76,6 +76,7 @@ int	lex_init_token(t_token *result)
 		exit(1);
 	}
 	result->length = 0;
+	result->type = TOKTYPE_PARSE_ERROR;
 	return (0);
 }
 

--- a/minishell.c
+++ b/minishell.c
@@ -60,8 +60,10 @@ int	do_command(char *cmdstr)
 	init_buffer_with_string(&buf, cmdstr);
 	buf.size++;
 	buf.buffer[len] = '\n';
+	lex_init_token(&tok);
 	lex_get_token(&buf, &tok);
 	cmdline = parse_command_line(&buf, &tok);
+	free(tok.text);
 	if (cmdline)
 	{
 		seqcmd = cmdline->content.command_line->seqcmd_node;

--- a/parse.h
+++ b/parse.h
@@ -11,7 +11,7 @@ typedef void				t_lexer_ungetc(struct s_parse_buffer *buf);
 
 typedef struct s_parse_buffer
 {
-	char			buffer[PARSE_BUFFER_SIZE *100];
+	char			buffer[PARSE_BUFFER_SIZE * 100];
 	int				size;
 	int				cur_pos;
 	t_lexer_state	lex_stat;

--- a/test/ast2cmdinvo_test.c
+++ b/test/ast2cmdinvo_test.c
@@ -249,6 +249,7 @@ int main()
 		t_parse_buffer	buf;
 		init_buf_with_string(&buf, "echo hoge$ABC\"hoge hoge\"'$ABC' \n");
 		t_token	tok;
+		lex_init_token(&tok);
 
 		lex_get_token(&buf, &tok);
 
@@ -274,6 +275,7 @@ int main()
 		printf("expanded: %s\n", expanded_str);
 		CHECK_EQ_STR(expanded_str, "hoge$ABC\"hoge hoge\"'$ABC'");
 		free(expanded_str);
+		free(tok.text);
 	}
 
 	TEST_SECTION("expand_string_node() 環境変数とクオーテーションマーク");
@@ -283,6 +285,7 @@ int main()
 		t_parse_buffer	buf;
 		init_buf_with_string(&buf, "echo hoge$ABC\"hoge hoge\"'$ABC' \n");
 		t_token	tok;
+		lex_init_token(&tok);
 
 		lex_get_token(&buf, &tok);
 
@@ -321,6 +324,7 @@ int main()
 		check_strarr((const char **)actual, (const char **)expected);
 		free_ptrarr((void **)actual);
 		free_ptrarr((void **)expected);
+		free(tok.text);
 	}
 
 	TEST_SECTION("expand_string_node() エスケープされた環境変数");
@@ -331,6 +335,7 @@ int main()
 		// echo "\$\$ABC\\$ABC""$ABC"
 		init_buf_with_string(&buf, "echo \"\\$\\$ABC\\\\$ABC\"\"$ABC\" \n");
 		t_token	tok;
+		lex_init_token(&tok);
 
 		lex_get_token(&buf, &tok);
 
@@ -376,6 +381,7 @@ int main()
 		check_strarr((const char **)actual, (const char **)expected);
 		free_ptrarr((void **)actual);
 		free_ptrarr((void **)expected);
+		free(tok.text);
 	}
 
 	TEST_CHAPTER("AST to command_invocation");
@@ -386,6 +392,7 @@ int main()
 		t_parse_buffer	buf;
 		init_buf_with_string(&buf, "abc \n");
 		t_token	tok;
+		lex_init_token(&tok);
 
 		lex_get_token(&buf, &tok);
 
@@ -403,6 +410,7 @@ int main()
 
 		cmd_free_cmdinvo(actual);
 		cmd_free_cmdinvo(expected);
+		free(tok.text);
 	}
 
 	TEST_SECTION("cmd_ast_cmd2cmdinvo arguments 2個");
@@ -411,6 +419,7 @@ int main()
 		t_parse_buffer	buf;
 		init_buf_with_string(&buf, "abc def\n");
 		t_token	tok;
+		lex_init_token(&tok);
 
 		lex_get_token(&buf, &tok);
 
@@ -425,6 +434,7 @@ int main()
 
 		cmd_free_cmdinvo(actual);
 		cmd_free_cmdinvo(expected);
+		free(tok.text);
 	}
 
 	TEST_SECTION("cmd_ast_cmd2cmdinvo() 空文字列を含む");
@@ -434,6 +444,7 @@ int main()
 		// echo a "" b "" c
 		init_buf_with_string(&buf, "echo a \"\" b \"\" c\n");
 		t_token	tok;
+		lex_init_token(&tok);
 
 		lex_get_token(&buf, &tok);
 
@@ -499,6 +510,7 @@ int main()
 
 		cmd_free_cmdinvo(actual);
 		cmd_free_cmdinvo(expected);
+		free(tok.text);
 	}
 
 	TEST_SECTION("cmd_ast_cmd2cmdinvo リダイレクト付き");
@@ -507,6 +519,7 @@ int main()
 		t_parse_buffer	buf;
 		init_buf_with_string(&buf, "file < abc \n");
 		t_token	tok;
+		lex_init_token(&tok);
 
 		lex_get_token(&buf, &tok);
 
@@ -522,6 +535,7 @@ int main()
 
 		cmd_free_cmdinvo(actual);
 		cmd_free_cmdinvo(expected);
+		free(tok.text);
 	}
 
 	TEST_SECTION("cmd_ast_cmd2cmdinvo 入力リダイレクト, ディスクリプタ");
@@ -530,6 +544,7 @@ int main()
 		t_parse_buffer	buf;
 		init_buf_with_string(&buf, "file 123< abc \n");
 		t_token	tok;
+		lex_init_token(&tok);
 
 		lex_get_token(&buf, &tok);
 
@@ -545,6 +560,7 @@ int main()
 
 		cmd_free_cmdinvo(actual);
 		cmd_free_cmdinvo(expected);
+		free(tok.text);
 	}
 
 	TEST_SECTION("cmd_ast_cmd2cmdinvo 出力リダイレクト付き");
@@ -553,6 +569,7 @@ int main()
 		t_parse_buffer	buf;
 		init_buf_with_string(&buf, "file > abc \n");
 		t_token	tok;
+		lex_init_token(&tok);
 
 		lex_get_token(&buf, &tok);
 
@@ -568,6 +585,7 @@ int main()
 
 		cmd_free_cmdinvo(actual);
 		cmd_free_cmdinvo(expected);
+		free(tok.text);
 	}
 
 	TEST_SECTION("cmd_ast_cmd2cmdinvo 出力リダイレクト, ディスクリプタ");
@@ -576,6 +594,7 @@ int main()
 		t_parse_buffer	buf;
 		init_buf_with_string(&buf, "file 123> abc \n");
 		t_token	tok;
+		lex_init_token(&tok);
 
 		lex_get_token(&buf, &tok);
 
@@ -591,6 +610,7 @@ int main()
 
 		cmd_free_cmdinvo(actual);
 		cmd_free_cmdinvo(expected);
+		free(tok.text);
 	}
 
 	TEST_SECTION("cmd_ast_cmd2cmdinvo 入出力リダイレクト付き");
@@ -599,6 +619,7 @@ int main()
 		t_parse_buffer	buf;
 		init_buf_with_string(&buf, "file < input > output \n");
 		t_token	tok;
+		lex_init_token(&tok);
 
 		lex_get_token(&buf, &tok);
 
@@ -615,6 +636,7 @@ int main()
 
 		cmd_free_cmdinvo(actual);
 		cmd_free_cmdinvo(expected);
+		free(tok.text);
 	}
 
 	TEST_SECTION("cmd_ast_cmd2cmdinvo 追記リダイレクト付き");
@@ -623,6 +645,7 @@ int main()
 		t_parse_buffer	buf;
 		init_buf_with_string(&buf, "file >> abc \n");
 		t_token	tok;
+		lex_init_token(&tok);
 
 		lex_get_token(&buf, &tok);
 
@@ -638,6 +661,7 @@ int main()
 
 		cmd_free_cmdinvo(actual);
 		cmd_free_cmdinvo(expected);
+		free(tok.text);
 	}
 
 	TEST_SECTION("cmd_ast_cmd2cmdinvo 追記リダイレクト, ディスクリプタ");
@@ -646,6 +670,7 @@ int main()
 		t_parse_buffer	buf;
 		init_buf_with_string(&buf, "file 456>> abc \n");
 		t_token	tok;
+		lex_init_token(&tok);
 
 		lex_get_token(&buf, &tok);
 
@@ -661,6 +686,7 @@ int main()
 
 		cmd_free_cmdinvo(actual);
 		cmd_free_cmdinvo(expected);
+		free(tok.text);
 	}
 
 
@@ -670,6 +696,7 @@ int main()
 		t_parse_buffer	buf;
 		init_buf_with_string(&buf, "file < a < b < c < d \n");
 		t_token	tok;
+		lex_init_token(&tok);
 
 		lex_get_token(&buf, &tok);
 
@@ -688,6 +715,7 @@ int main()
 
 		cmd_free_cmdinvo(actual);
 		cmd_free_cmdinvo(expected);
+		free(tok.text);
 	}
 
 	TEST_SECTION("cmd_ast_cmd2cmdinvo 複数書き込みリダイレクト");
@@ -696,6 +724,7 @@ int main()
 		t_parse_buffer	buf;
 		init_buf_with_string(&buf, "file > a > b > c > d \n");
 		t_token	tok;
+		lex_init_token(&tok);
 
 		lex_get_token(&buf, &tok);
 
@@ -714,6 +743,7 @@ int main()
 
 		cmd_free_cmdinvo(actual);
 		cmd_free_cmdinvo(expected);
+		free(tok.text);
 	}
 
 	TEST_SECTION("cmd_ast_cmd2cmdinvo 複数追記リダイレクト");
@@ -722,6 +752,7 @@ int main()
 		t_parse_buffer	buf;
 		init_buf_with_string(&buf, "file >> a >> b >> c >> d \n");
 		t_token	tok;
+		lex_init_token(&tok);
 
 		lex_get_token(&buf, &tok);
 
@@ -740,6 +771,7 @@ int main()
 
 		cmd_free_cmdinvo(actual);
 		cmd_free_cmdinvo(expected);
+		free(tok.text);
 	}
 
 	TEST_SECTION("cmd_ast_cmd2cmdinvo 複数入力リダイレクト");
@@ -748,6 +780,7 @@ int main()
 		t_parse_buffer	buf;
 		init_buf_with_string(&buf, "file < a < b > c > d \n");
 		t_token	tok;
+		lex_init_token(&tok);
 
 		lex_get_token(&buf, &tok);
 
@@ -766,6 +799,7 @@ int main()
 
 		cmd_free_cmdinvo(actual);
 		cmd_free_cmdinvo(expected);
+		free(tok.text);
 	}
 
 	TEST_SECTION("cmd_ast_cmd2cmdinvo 環境変数");
@@ -775,6 +809,7 @@ int main()
 		t_parse_buffer	buf;
 		init_buf_with_string(&buf, "echo $ABC \n");
 		t_token	tok;
+		lex_init_token(&tok);
 
 		lex_get_token(&buf, &tok);
 
@@ -797,6 +832,7 @@ int main()
 		cmd_free_cmdinvo(actual);
 		cmd_free_cmdinvo(expected);
 		unsetenv("ABC");
+		free(tok.text);
 	}
 
 	TEST_SECTION("cmd_ast_cmd2cmdinvo ダブルクオーテーションで囲まれた環境変数");
@@ -806,6 +842,7 @@ int main()
 		t_parse_buffer	buf;
 		init_buf_with_string(&buf, "echo \"$ABC\" \n");
 		t_token	tok;
+		lex_init_token(&tok);
 
 		lex_get_token(&buf, &tok);
 
@@ -828,6 +865,7 @@ int main()
 		cmd_free_cmdinvo(actual);
 		cmd_free_cmdinvo(expected);
 		unsetenv("ABC");
+		free(tok.text);
 	}
 
 	TEST_SECTION("cmd_ast_cmd2cmdinvo シングルクオーテーションで囲まれた環境変数");
@@ -837,6 +875,7 @@ int main()
 		t_parse_buffer	buf;
 		init_buf_with_string(&buf, "echo \'$ABC\' \n");
 		t_token	tok;
+		lex_init_token(&tok);
 
 		lex_get_token(&buf, &tok);
 
@@ -859,6 +898,7 @@ int main()
 		cmd_free_cmdinvo(actual);
 		cmd_free_cmdinvo(expected);
 		unsetenv("ABC");
+		free(tok.text);
 	}
 
 
@@ -869,6 +909,7 @@ int main()
 		t_parse_buffer	buf;
 		init_buf_with_string(&buf, "echo $ABC \n");
 		t_token	tok;
+		lex_init_token(&tok);
 
 		lex_get_token(&buf, &tok);
 
@@ -891,6 +932,7 @@ int main()
 		cmd_free_cmdinvo(actual);
 		cmd_free_cmdinvo(expected);
 		unsetenv("ABC");
+		free(tok.text);
 	}
 
 	TEST_SECTION("cmd_ast_cmd2cmdinvo 文字列と環境変数");
@@ -900,6 +942,7 @@ int main()
 		t_parse_buffer	buf;
 		init_buf_with_string(&buf, "echo hoge$ABC \n");
 		t_token	tok;
+		lex_init_token(&tok);
 
 		lex_get_token(&buf, &tok);
 
@@ -925,6 +968,7 @@ int main()
 		cmd_free_cmdinvo(actual);
 		cmd_free_cmdinvo(expected);
 		unsetenv("ABC");
+		free(tok.text);
 	}
 
 
@@ -935,6 +979,7 @@ int main()
 		t_parse_buffer	buf;
 		init_buf_with_string(&buf, "echo $ABC\"ghi jkl\" \n");
 		t_token	tok;
+		lex_init_token(&tok);
 
 		lex_get_token(&buf, &tok);
 
@@ -964,6 +1009,7 @@ int main()
 		cmd_free_cmdinvo(actual);
 		cmd_free_cmdinvo(expected);
 		unsetenv("ABC");
+		free(tok.text);
 	}
 
 	TEST_SECTION("cmd_ast_cmd2cmdinvo 環境変数が複数");
@@ -974,6 +1020,7 @@ int main()
 		t_parse_buffer	buf;
 		init_buf_with_string(&buf, "echo $ABC$DEF \n");
 		t_token	tok;
+		lex_init_token(&tok);
 
 		lex_get_token(&buf, &tok);
 
@@ -1002,6 +1049,7 @@ int main()
 		cmd_free_cmdinvo(expected);
 		unsetenv("ABC");
 		unsetenv("DEF");
+		free(tok.text);
 	}
 
 	TEST_SECTION("cmd_ast_cmd2cmdinvo リダイレクション 環境変数");
@@ -1011,6 +1059,7 @@ int main()
 		t_parse_buffer	buf;
 		init_buf_with_string(&buf, "echo hello > $ABC \n");
 		t_token	tok;
+		lex_init_token(&tok);
 
 		lex_get_token(&buf, &tok);
 
@@ -1037,6 +1086,7 @@ int main()
 		cmd_free_cmdinvo(actual);
 		cmd_free_cmdinvo(expected);
 		unsetenv("ABC");
+		free(tok.text);
 	}
 
 	TEST_SECTION("cmd_ast_cmd2cmdinvo リダイレクション 環境変数と文字列");
@@ -1046,6 +1096,7 @@ int main()
 		t_parse_buffer	buf;
 		init_buf_with_string(&buf, "echo hello > hoge$ABC \n");
 		t_token	tok;
+		lex_init_token(&tok);
 
 		lex_get_token(&buf, &tok);
 
@@ -1078,6 +1129,7 @@ int main()
 		cmd_free_cmdinvo(actual);
 		cmd_free_cmdinvo(expected);
 		unsetenv("ABC");
+		free(tok.text);
 	}
 
 	TEST_SECTION("cmd_ast_cmd2cmdinvo 存在しない環境変数");
@@ -1086,6 +1138,7 @@ int main()
 		t_parse_buffer	buf;
 		init_buf_with_string(&buf, "echo $DONTEXISTS \n");
 		t_token	tok;
+		lex_init_token(&tok);
 
 		lex_get_token(&buf, &tok);
 
@@ -1107,6 +1160,7 @@ int main()
 
 		cmd_free_cmdinvo(actual);
 		cmd_free_cmdinvo(expected);
+		free(tok.text);
 	}
 
 	TEST_SECTION("cmd_ast_pipcmds2cmdinvo 文字列1つ");
@@ -1115,6 +1169,7 @@ int main()
 		t_parse_buffer	buf;
 		init_buf_with_string(&buf, "abc \n");
 		t_token	tok;
+		lex_init_token(&tok);
 
 		lex_get_token(&buf, &tok);
 
@@ -1132,6 +1187,7 @@ int main()
 
 		cmd_free_cmdinvo(actual);
 		cmd_free_cmdinvo(expected);
+		free(tok.text);
 	}
 
 	TEST_SECTION("cmd_ast_pipcmds2cmdinvo arguments 2個");
@@ -1140,6 +1196,7 @@ int main()
 		t_parse_buffer	buf;
 		init_buf_with_string(&buf, "abc def\n");
 		t_token	tok;
+		lex_init_token(&tok);
 
 		lex_get_token(&buf, &tok);
 
@@ -1154,6 +1211,7 @@ int main()
 
 		cmd_free_cmdinvo(actual);
 		cmd_free_cmdinvo(expected);
+		free(tok.text);
 	}
 
 	TEST_SECTION("cmd_ast_pipcmds2cmdinvo パイプ & リダイレクション");
@@ -1162,6 +1220,7 @@ int main()
 		t_parse_buffer	buf;
 		init_buf_with_string(&buf, "abc | file < abc \n");
 		t_token	tok;
+		lex_init_token(&tok);
 
 		lex_get_token(&buf, &tok);
 
@@ -1179,6 +1238,7 @@ int main()
 
 		cmd_free_cmdinvo(actual);
 		cmd_free_cmdinvo(expected_first);
+		free(tok.text);
 	}
 
 	TEST_SECTION("cmd_ast_pipcmds2cmdinvo パイプ & 出力リダイレクション");
@@ -1187,6 +1247,7 @@ int main()
 		t_parse_buffer	buf;
 		init_buf_with_string(&buf, "abc | file > abc \n");
 		t_token	tok;
+		lex_init_token(&tok);
 
 		lex_get_token(&buf, &tok);
 
@@ -1204,6 +1265,7 @@ int main()
 
 		cmd_free_cmdinvo(actual);
 		cmd_free_cmdinvo(expected_first);
+		free(tok.text);
 	}
 
 	free_vars(g_shell.vars);

--- a/test/parse_test.c
+++ b/test/parse_test.c
@@ -30,9 +30,11 @@ void test_lexer()
 		t_parse_buffer	buf;
 		init_buf_with_string(&buf, "cat ");
 		t_token	tok;
+		lex_init_token(&tok);
 		lex_read_word(&buf, &tok);
 		CHECK_EQ(tok.length, 3);
 		CHECK(!strncmp(tok.text, "cat", 3));
+		free(tok.text);
 	}
 
 	TEST_SECTION("lex_get_token デスクリプタ付きのリダイレクト");
@@ -40,6 +42,7 @@ void test_lexer()
 		t_parse_buffer	buf;
 		init_buf_with_string(&buf, "10< 123> 456>> ");
 		t_token	tok;
+		lex_init_token(&tok);
 
 		lex_get_token(&buf, &tok);
 		CHECK_EQ(tok.type, TOKTYPE_INPUT_REDIRECTION);
@@ -58,6 +61,7 @@ void test_lexer()
 		lex_get_token(&buf, &tok);
 		CHECK_EQ(tok.type, TOKTYPE_OUTPUT_APPENDING);
 		CHECK_EQ(tok.length, 456);
+		free(tok.text);
 	}
 
 	TEST_SECTION("lex_get_token クォートなしの場合");
@@ -65,6 +69,7 @@ void test_lexer()
 		t_parse_buffer	buf;
 		init_buf_with_string(&buf, "cat $ABC |wc> file.txt\n");
 		t_token	tok;
+		lex_init_token(&tok);
 
 		lex_get_token(&buf, &tok);
 		CHECK_EQ(tok.type, TOKTYPE_EXPANDABLE);
@@ -103,6 +108,7 @@ void test_lexer()
 
 		lex_get_token(&buf, &tok);
 		CHECK_EQ(tok.type, TOKTYPE_NEWLINE);
+		free(tok.text);
 	}
 
 	TEST_SECTION("lex_get_token クォートなしエスケープありの場合");
@@ -111,6 +117,7 @@ void test_lexer()
 		// \$ABC c\ at \"xyz
 		init_buf_with_string(&buf, "\\$ABC c\\ at \\\"xyz \n");
 		t_token	tok;
+		lex_init_token(&tok);
 
 		lex_get_token(&buf, &tok);
 		CHECK_EQ(tok.type, TOKTYPE_NON_EXPANDABLE);
@@ -158,6 +165,7 @@ void test_lexer()
 
 		lex_get_token(&buf, &tok);
 		CHECK_EQ(tok.type, TOKTYPE_NEWLINE);
+		free(tok.text);
 	}
 
 	TEST_SECTION("lex_get_token クォートありの場合");
@@ -165,6 +173,7 @@ void test_lexer()
 		t_parse_buffer	buf;
 		init_buf_with_string(&buf, "cat\"$ABC\"'wc'");
 		t_token	tok;
+		lex_init_token(&tok);
 
 		lex_get_token(&buf, &tok);
 		CHECK_EQ(tok.type, TOKTYPE_EXPANDABLE);
@@ -180,6 +189,7 @@ void test_lexer()
 		CHECK_EQ(tok.type, TOKTYPE_NON_EXPANDABLE);
 		CHECK_EQ(tok.length, 2);
 		CHECK(!strncmp(tok.text, "wc", 2));
+		free(tok.text);
 	}
 
 	TEST_SECTION("lex_get_token クォートありエスケープあり");
@@ -187,6 +197,7 @@ void test_lexer()
 		t_parse_buffer	buf;
 		init_buf_with_string(&buf, "\"\\$ABC\" '\\abc'");
 		t_token	tok;
+		lex_init_token(&tok);
 
 		lex_get_token(&buf, &tok);
 		CHECK_EQ(tok.type, TOKTYPE_NON_EXPANDABLE);
@@ -205,6 +216,7 @@ void test_lexer()
 		CHECK_EQ(tok.type, TOKTYPE_NON_EXPANDABLE);
 		CHECK_EQ(tok.length, 4);
 		CHECK(!strncmp(tok.text, "\\abc", 4));
+		free(tok.text);
 	}
 
 	TEST_SECTION("lex_get_token クォートありエスケープ2つあり");
@@ -212,6 +224,7 @@ void test_lexer()
 		t_parse_buffer	buf;
 		init_buf_with_string(&buf, "\"\\\\$ABC\" '\\\\abc'");
 		t_token	tok;
+		lex_init_token(&tok);
 
 		lex_get_token(&buf, &tok);
 		CHECK_EQ(tok.type, TOKTYPE_NON_EXPANDABLE);
@@ -230,6 +243,7 @@ void test_lexer()
 		CHECK_EQ(tok.type, TOKTYPE_NON_EXPANDABLE);
 		CHECK_EQ(tok.length, 5);
 		CHECK(!strncmp(tok.text, "\\\\abc", 5));
+		free(tok.text);
 	}
 
 	TEST_SECTION("lex_get_token 数字だけのトークン");
@@ -237,6 +251,7 @@ void test_lexer()
 		t_parse_buffer	buf;
 		init_buf_with_string(&buf, "111 22 abcd ");
 		t_token	tok;
+		lex_init_token(&tok);
 
 		lex_get_token(&buf, &tok);
 		CHECK_EQ(tok.type, TOKTYPE_EXPANDABLE);
@@ -258,6 +273,7 @@ void test_lexer()
 		CHECK_EQ(tok.type, TOKTYPE_EXPANDABLE);
 		CHECK_EQ(tok.length, 4);
 		CHECK(!strncmp(tok.text, "abcd", 4));
+		free(tok.text);
 	}
 
 	TEST_SECTION("lex_get_token #88");
@@ -265,6 +281,7 @@ void test_lexer()
 		t_parse_buffer	buf;
 		init_buf_with_string(&buf, "chmod 000 dir ");
 		t_token	tok;
+		lex_init_token(&tok);
 
 		lex_get_token(&buf, &tok);
 		CHECK_EQ(tok.type, TOKTYPE_EXPANDABLE);
@@ -286,6 +303,7 @@ void test_lexer()
 		CHECK_EQ(tok.type, TOKTYPE_EXPANDABLE);
 		CHECK_EQ(tok.length, 3);
 		CHECK(!strncmp(tok.text, "dir", 3));
+		free(tok.text);
 	}
 
 	TEST_SECTION("lex_get_token のこり");
@@ -293,6 +311,7 @@ void test_lexer()
 		t_parse_buffer	buf;
 		init_buf_with_string(&buf, "cat < - ; ");
 		t_token	tok;
+		lex_init_token(&tok);
 
 		lex_get_token(&buf, &tok);
 		CHECK_EQ(tok.type, TOKTYPE_EXPANDABLE);
@@ -319,6 +338,7 @@ void test_lexer()
 
 		lex_get_token(&buf, &tok);
 		CHECK_EQ(tok.type, TOKTYPE_SEMICOLON);
+		free(tok.text);
 	}
 
 	TEST_SECTION("lex_get_token EOF");
@@ -326,8 +346,10 @@ void test_lexer()
 		t_parse_buffer	buf;
 		init_buf_with_string(&buf, "");
 		t_token	tok;
+		lex_init_token(&tok);
 		lex_get_token(&buf, &tok);
 		CHECK_EQ(tok.type, TOKTYPE_EOF);
+		free(tok.text);
 	}
 }
 
@@ -416,6 +438,7 @@ void test_parser(void)
 		t_parse_buffer	buf;
 		init_buf_with_string(&buf, "file\n");
 		t_token	tok;
+		lex_init_token(&tok);
 
 		lex_get_token(&buf, &tok);
 
@@ -425,6 +448,7 @@ void test_parser(void)
 		CHECK_EQ(node->content.string->type, TOKTYPE_EXPANDABLE);
 		CHECK_EQ_STR(node->content.string->text, "file");
 		CHECK_EQ(node->content.string->next, NULL);
+		free(tok.text);
 	}
 
 	TEST_SECTION("parse_string シングルクォート");
@@ -432,6 +456,7 @@ void test_parser(void)
 		t_parse_buffer	buf;
 		init_buf_with_string(&buf, "'file'\n");
 		t_token	tok;
+		lex_init_token(&tok);
 
 		lex_get_token(&buf, &tok);
 
@@ -441,6 +466,7 @@ void test_parser(void)
 		CHECK_EQ(node->content.string->type, TOKTYPE_NON_EXPANDABLE);
 		CHECK_EQ_STR(node->content.string->text, "file");
 		CHECK_EQ(node->content.string->next, NULL);
+		free(tok.text);
 	}
 
 	TEST_SECTION("parse_string ダブルクォート");
@@ -448,6 +474,7 @@ void test_parser(void)
 		t_parse_buffer	buf;
 		init_buf_with_string(&buf, "\"file\"\n");
 		t_token	tok;
+		lex_init_token(&tok);
 
 		lex_get_token(&buf, &tok);
 
@@ -457,6 +484,7 @@ void test_parser(void)
 		CHECK_EQ(node->content.string->type, TOKTYPE_EXPANDABLE_QUOTED);
 		CHECK_EQ_STR(node->content.string->text, "file");
 		CHECK_EQ(node->content.string->next, NULL);
+		free(tok.text);
 	}
 
 	TEST_SECTION("parse_string ミックス");
@@ -464,6 +492,7 @@ void test_parser(void)
 		t_parse_buffer	buf;
 		init_buf_with_string(&buf, "abc\"def\"'ghi'\n");
 		t_token	tok;
+		lex_init_token(&tok);
 
 		lex_get_token(&buf, &tok);
 
@@ -484,6 +513,7 @@ void test_parser(void)
 		CHECK_EQ(node->type, ASTNODE_STRING);
 		CHECK_EQ(node->content.string->type, TOKTYPE_NON_EXPANDABLE);
 		CHECK_EQ_STR(node->content.string->text, "ghi");
+		free(tok.text);
 	}
 
 	TEST_SECTION("parse_redirection　<");
@@ -491,6 +521,7 @@ void test_parser(void)
 		t_parse_buffer	buf;
 		init_buf_with_string(&buf, "< file\n");
 		t_token	tok;
+		lex_init_token(&tok);
 
 		lex_get_token(&buf, &tok);
 
@@ -501,6 +532,7 @@ void test_parser(void)
 		CHECK_EQ(node->content.redirection->type, TOKTYPE_INPUT_REDIRECTION);
 		CHECK_EQ_STR(node->content.redirection->string_node
 					->content.string->text, "file");
+		free(tok.text);
 	}
 
 	TEST_SECTION("parse_redirection デスクリプタ付き <");
@@ -508,6 +540,7 @@ void test_parser(void)
 		t_parse_buffer	buf;
 		init_buf_with_string(&buf, "123< file\n");
 		t_token	tok;
+		lex_init_token(&tok);
 
 		lex_get_token(&buf, &tok);
 
@@ -518,6 +551,7 @@ void test_parser(void)
 		CHECK_EQ(node->content.redirection->type, TOKTYPE_INPUT_REDIRECTION);
 		CHECK_EQ_STR(node->content.redirection->string_node
 					->content.string->text, "file");
+		free(tok.text);
 	}
 
 	TEST_SECTION("parse_redirection　>");
@@ -525,6 +559,7 @@ void test_parser(void)
 		t_parse_buffer	buf;
 		init_buf_with_string(&buf, "> file\n");
 		t_token	tok;
+		lex_init_token(&tok);
 
 		lex_get_token(&buf, &tok);
 
@@ -535,6 +570,7 @@ void test_parser(void)
 		CHECK_EQ(node->content.redirection->type, TOKTYPE_OUTPUT_REDIRECTION);
 		CHECK_EQ_STR(node->content.redirection->string_node
 					 ->content.string->text, "file");
+		free(tok.text);
 	}
 
 	TEST_SECTION("parse_redirection　デスクリプタ付き >");
@@ -542,6 +578,7 @@ void test_parser(void)
 		t_parse_buffer	buf;
 		init_buf_with_string(&buf, "123> file\n");
 		t_token	tok;
+		lex_init_token(&tok);
 
 		lex_get_token(&buf, &tok);
 
@@ -552,6 +589,7 @@ void test_parser(void)
 		CHECK_EQ(node->content.redirection->type, TOKTYPE_OUTPUT_REDIRECTION);
 		CHECK_EQ_STR(node->content.redirection->string_node
 					 ->content.string->text, "file");
+		free(tok.text);
 	}
 
 	TEST_SECTION("parse_redirection　fdの最大最大値付き >");
@@ -560,6 +598,7 @@ void test_parser(void)
 		t_parse_buffer	buf;
 		init_buf_with_string(&buf, "2147483647> file\n");
 		t_token	tok;
+		lex_init_token(&tok);
 
 		lex_get_token(&buf, &tok);
 
@@ -570,6 +609,7 @@ void test_parser(void)
 		CHECK_EQ(node->content.redirection->type, TOKTYPE_OUTPUT_REDIRECTION);
 		CHECK_EQ_STR(node->content.redirection->string_node
 					 ->content.string->text, "file");
+		free(tok.text);
 	}
 
 	TEST_SECTION("parse_redirection　fdがINTMAX超過 >");
@@ -578,6 +618,7 @@ void test_parser(void)
 		t_parse_buffer	buf;
 		init_buf_with_string(&buf, "2147483648> file\n");
 		t_token	tok;
+		lex_init_token(&tok);
 
 		lex_get_token(&buf, &tok);
 		t_parse_ast *string_node = parse_string(&buf, &tok);
@@ -592,6 +633,7 @@ void test_parser(void)
 		CHECK_EQ(node->content.redirection->type, TOKTYPE_OUTPUT_REDIRECTION);
 		CHECK_EQ_STR(node->content.redirection->string_node
 					 ->content.string->text, "file");
+		free(tok.text);
 	}
 
 	TEST_SECTION("parse_redirection　>>");
@@ -599,6 +641,7 @@ void test_parser(void)
 		t_parse_buffer	buf;
 		init_buf_with_string(&buf, ">> file\n");
 		t_token	tok;
+		lex_init_token(&tok);
 
 		lex_get_token(&buf, &tok);
 
@@ -609,6 +652,7 @@ void test_parser(void)
 		CHECK_EQ(node->content.redirection->type, TOKTYPE_OUTPUT_APPENDING);
 		CHECK_EQ_STR(node->content.redirection->string_node
 					->content.string->text, "file");
+		free(tok.text);
 	}
 
 	TEST_SECTION("parse_redirection デスクリプタ付き >>");
@@ -616,6 +660,7 @@ void test_parser(void)
 		t_parse_buffer	buf;
 		init_buf_with_string(&buf, "456>> file\n");
 		t_token	tok;
+		lex_init_token(&tok);
 
 		lex_get_token(&buf, &tok);
 
@@ -626,6 +671,7 @@ void test_parser(void)
 		CHECK_EQ(node->content.redirection->type, TOKTYPE_OUTPUT_APPENDING);
 		CHECK_EQ_STR(node->content.redirection->string_node
 					->content.string->text, "file");
+		free(tok.text);
 	}
 
 	TEST_SECTION("parse_arguments 1 個");
@@ -633,6 +679,7 @@ void test_parser(void)
 		t_parse_buffer	buf;
 		init_buf_with_string(&buf, "abc \n");
 		t_token	tok;
+		lex_init_token(&tok);
 
 		lex_get_token(&buf, &tok);
 
@@ -643,6 +690,7 @@ void test_parser(void)
 		CHECK(str_node);
 		CHECK_EQ(str_node->type, ASTNODE_STRING);
 		CHECK_EQ_STR(str_node->content.string->text, "abc");
+		free(tok.text);
 	}
 
 	TEST_SECTION("parse_arguments 1 個直後に改行");
@@ -650,6 +698,7 @@ void test_parser(void)
 		t_parse_buffer	buf;
 		init_buf_with_string(&buf, "abc\n");
 		t_token	tok;
+		lex_init_token(&tok);
 
 		lex_get_token(&buf, &tok);
 
@@ -660,6 +709,7 @@ void test_parser(void)
 		CHECK(str_node);
 		CHECK_EQ(str_node->type, ASTNODE_STRING);
 		CHECK_EQ_STR(str_node->content.string->text, "abc");
+		free(tok.text);
 	}
 
 	TEST_SECTION("parse_arguments 2 個");
@@ -667,6 +717,7 @@ void test_parser(void)
 		t_parse_buffer	buf;
 		init_buf_with_string(&buf, "abc def \n");
 		t_token	tok;
+		lex_init_token(&tok);
 
 		lex_get_token(&buf, &tok);
 
@@ -685,6 +736,7 @@ void test_parser(void)
 		CHECK(str_node);
 		CHECK_EQ(str_node->type, ASTNODE_STRING);
 		CHECK_EQ_STR(str_node->content.string->text, "def");
+		free(tok.text);
 	}
 
 	TEST_SECTION("parse_arguments リダイレクト");
@@ -692,6 +744,7 @@ void test_parser(void)
 		t_parse_buffer	buf;
 		init_buf_with_string(&buf, "< abc \n");
 		t_token	tok;
+		lex_init_token(&tok);
 
 		lex_get_token(&buf, &tok);
 
@@ -705,6 +758,7 @@ void test_parser(void)
 		CHECK_EQ(red_node->content.redirection->type, TOKTYPE_INPUT_REDIRECTION);
 		CHECK_EQ_STR(red_node->content.redirection->string_node
 					->content.string->text, "abc");
+		free(tok.text);
 	}
 
 	TEST_SECTION("parse_arguments ファイル + リダイレクト");
@@ -712,11 +766,13 @@ void test_parser(void)
 		t_parse_buffer	buf;
 		init_buf_with_string(&buf, "file < abc \n");
 		t_token	tok;
+		lex_init_token(&tok);
 
 		lex_get_token(&buf, &tok);
 
 		t_parse_ast *node = parse_arguments(&buf, &tok);
 		check_args(node);
+		free(tok.text);
 	}
 
 	TEST_SECTION("parse_arguments ファイル + リダイレクト 2 個");
@@ -724,6 +780,7 @@ void test_parser(void)
 		t_parse_buffer	buf;
 		init_buf_with_string(&buf, "file < abc < def\n");
 		t_token	tok;
+		lex_init_token(&tok);
 
 		lex_get_token(&buf, &tok);
 
@@ -738,6 +795,7 @@ void test_parser(void)
 		node = node->content.arguments->rest_node;
 		red_node = node->content.arguments->redirection_node;
 		check_redirection(red_node, "def");
+		free(tok.text);
 	}
 
 	TEST_SECTION("parse_arguments ファイル + 出力リダイレクト 2 個");
@@ -745,6 +803,7 @@ void test_parser(void)
 		t_parse_buffer	buf;
 		init_buf_with_string(&buf, "file > abc > def\n");
 		t_token	tok;
+		lex_init_token(&tok);
 
 		lex_get_token(&buf, &tok);
 
@@ -759,6 +818,7 @@ void test_parser(void)
 		node = node->content.arguments->rest_node;
 		red_node = node->content.arguments->redirection_node;
 		check_output_redirection(red_node, "def");
+		free(tok.text);
 	}
 
 	TEST_SECTION("parse_command ファイル + リダイレクト");
@@ -766,12 +826,14 @@ void test_parser(void)
 		t_parse_buffer	buf;
 		init_buf_with_string(&buf, "file < abc \n");
 		t_token	tok;
+		lex_init_token(&tok);
 
 		lex_get_token(&buf, &tok);
 
 		t_parse_ast *node = parse_command(&buf, &tok);
 		CHECK_EQ(node->type, ASTNODE_COMMAND);
 		check_args(node->content.command->arguments_node);
+		free(tok.text);
 	}
 
 	TEST_SECTION("parse_piped_commands パイプなし");
@@ -779,6 +841,7 @@ void test_parser(void)
 		t_parse_buffer	buf;
 		init_buf_with_string(&buf, "abc \n");
 		t_token	tok;
+		lex_init_token(&tok);
 
 		lex_get_token(&buf, &tok);
 
@@ -793,6 +856,7 @@ void test_parser(void)
 		CHECK(str);
 		CHECK_EQ_STR(str->content.string->text, "abc");
 		CHECK(!node->content.piped_commands->next);
+		free(tok.text);
 	}
 
 	TEST_SECTION("parse_piped_commands パイプあり");
@@ -800,11 +864,13 @@ void test_parser(void)
 		t_parse_buffer	buf;
 		init_buf_with_string(&buf, "abc | file < abc \n");
 		t_token	tok;
+		lex_init_token(&tok);
 
 		lex_get_token(&buf, &tok);
 
 		t_parse_ast *node = parse_piped_commands(&buf, &tok);
 		check_piped_commands(node);
+		free(tok.text);
 	}
 
 	TEST_SECTION("parse_delimiter");
@@ -812,10 +878,12 @@ void test_parser(void)
 		t_parse_buffer	buf;
 		init_buf_with_string(&buf, "; \n");
 		t_token	tok;
+		lex_init_token(&tok);
 
 		lex_get_token(&buf, &tok);
 		t_parse_ast *node = parse_delimiter(&buf, &tok);
 		check_delimiter(node);
+		free(tok.text);
 	}
 
 	TEST_SECTION("parse_sequential_commands 単純なケース");
@@ -823,6 +891,7 @@ void test_parser(void)
 		t_parse_buffer	buf;
 		init_buf_with_string(&buf, " abc ; xyz \n");
 		t_token	tok;
+		lex_init_token(&tok);
 
 		lex_get_token(&buf, &tok);
 		t_parse_ast *node = parse_sequential_commands(&buf, &tok);
@@ -842,6 +911,7 @@ void test_parser(void)
 			->command_node->content.command
 			->arguments_node,
 			"xyz");
+		free(tok.text);
 	}
 
 	TEST_SECTION("parse_sequential_commands セミコロンで終わる");
@@ -849,6 +919,7 @@ void test_parser(void)
 		t_parse_buffer	buf;
 		init_buf_with_string(&buf, " abc ; xyz ;\n");
 		t_token	tok;
+		lex_init_token(&tok);
 
 		lex_get_token(&buf, &tok);
 		t_parse_ast *node = parse_sequential_commands(&buf, &tok);
@@ -872,6 +943,7 @@ void test_parser(void)
 			node->content.sequential_commands
 			->rest_node->content.sequential_commands
 			->delimiter_node);
+		free(tok.text);
 	}
 
 	TEST_SECTION("parse_sequential_commands パイプあり");
@@ -879,11 +951,13 @@ void test_parser(void)
 		t_parse_buffer	buf;
 		init_buf_with_string(&buf, " abc | file < abc ; xyz \n");
 		t_token	tok;
+		lex_init_token(&tok);
 
 		lex_get_token(&buf, &tok);
 		t_parse_ast *node = parse_sequential_commands(&buf, &tok);
 
 		check_piped_seqence(node);
+		free(tok.text);
 	}
 
 	TEST_SECTION("parse_command_line パイプなし");
@@ -891,6 +965,7 @@ void test_parser(void)
 		t_parse_buffer	buf;
 		init_buf_with_string(&buf, "abc\n");
 		t_token	tok;
+		lex_init_token(&tok);
 
 		lex_get_token(&buf, &tok);
 		t_parse_ast *node = parse_command_line(&buf, &tok);
@@ -901,6 +976,7 @@ void test_parser(void)
 			->command_node->content.command
 			->arguments_node,
 			"abc");
+		free(tok.text);
 	}
 
 	TEST_SECTION("parse_command_line");
@@ -908,11 +984,13 @@ void test_parser(void)
 		t_parse_buffer	buf;
 		init_buf_with_string(&buf, " abc | file < abc ; xyz \n");
 		t_token	tok;
+		lex_init_token(&tok);
 
 		lex_get_token(&buf, &tok);
 		t_parse_ast *node = parse_command_line(&buf, &tok);
 
 		check_piped_seqence(node->content.command_line->seqcmd_node);
+		free(tok.text);
 	}
 
 	TEST_SECTION("parse_command_line バックスラッシュで終わる");
@@ -920,6 +998,7 @@ void test_parser(void)
 		t_parse_buffer	buf;
 		init_buf_with_string(&buf, "abc\\\n");
 		t_token	tok;
+		lex_init_token(&tok);
 
 		lex_get_token(&buf, &tok);
 		t_parse_ast *node = parse_command_line(&buf, &tok);
@@ -931,6 +1010,7 @@ void test_parser(void)
 			->command_node->content.command
 			->arguments_node,
 			"abc");
+		free(tok.text);
 	}
 
 	TEST_SECTION("parse_command_line 閉じてないダブルクォート");
@@ -938,10 +1018,12 @@ void test_parser(void)
 		t_parse_buffer	buf;
 		init_buf_with_string(&buf, "abc\"\n");
 		t_token	tok;
+		lex_init_token(&tok);
 
 		lex_get_token(&buf, &tok);
 		t_parse_ast *node = parse_command_line(&buf, &tok);
 		CHECK(!node);
+		free(tok.text);
 	}
 
 	TEST_SECTION("parse_command_line 閉じてないシングルクォート");
@@ -949,10 +1031,12 @@ void test_parser(void)
 		t_parse_buffer	buf;
 		init_buf_with_string(&buf, "abc'\n");
 		t_token	tok;
+		lex_init_token(&tok);
 
 		lex_get_token(&buf, &tok);
 		t_parse_ast *node = parse_command_line(&buf, &tok);
 		CHECK(!node);
+		free(tok.text);
 	}
 
 	TEST_SECTION("parse_command_line セミコロンで終わる");
@@ -960,6 +1044,7 @@ void test_parser(void)
 		t_parse_buffer	buf;
 		init_buf_with_string(&buf, " abc ; xyz ;\n");
 		t_token	tok;
+		lex_init_token(&tok);
 
 		lex_get_token(&buf, &tok);
 		t_parse_ast *node = parse_command_line(&buf, &tok);
@@ -987,6 +1072,7 @@ void test_parser(void)
 			node->content.sequential_commands
 			->rest_node->content.sequential_commands
 			->delimiter_node);
+		free(tok.text);
 	}
 
 	TEST_SECTION("parse_command_line セミコロンだけのときはエラー");
@@ -994,163 +1080,12 @@ void test_parser(void)
 		t_parse_buffer	buf;
 		init_buf_with_string(&buf, " ;\n");
 		t_token	tok;
+		lex_init_token(&tok);
 
 		lex_get_token(&buf, &tok);
 		t_parse_ast *node = parse_command_line(&buf, &tok);
 		CHECK(!node);
-	}
-
-#define T8 "abcdefgh"
-#define T16 T8 T8
-#define T32 T16 T16
-#define T64 T32 T32
-#define T128 T64 T64
-#define T896 T128 T128 T128 T128 T128 T128 T128
-#define T1016 T896 T64 T32 T16 T8
-#define T1024 T896 T128
-#define T1280 T1024 T128 T128
-
-	TEST_SECTION("parse_command_line 長い行は 1024 文字ごとに分ける");
-	{
-		t_parse_buffer	buf;
-		init_buf_with_string(&buf, T1280 "\n");
-		t_token	tok;
-
-		lex_get_token(&buf, &tok);
-		t_parse_ast *node = parse_command_line(&buf, &tok);
-		CHECK(node);
-
-		node = node->content.command_line->seqcmd_node
-			->content.sequential_commands
-			->pipcmd_node->content.piped_commands
-			->command_node->content.command
-			->arguments_node;
-		CHECK_EQ(node->type, ASTNODE_ARGUMENTS);
-		check_single_argument(node, T1024);
-
-		node = node->content.arguments->string_node;
-		CHECK_EQ(node->type, ASTNODE_STRING);
-		CHECK_EQ(node->content.string->type, TOKTYPE_EXPANDABLE);
-
-		// のこり
-		node = node->content.string->next;
-		CHECK_EQ(node->type, ASTNODE_STRING);
-		CHECK_EQ(node->content.string->type, TOKTYPE_EXPANDABLE);
-		check_string(node, T128 T128); /* 256 */
-	}
-
-	TEST_SECTION("parse_command_line 長い行の最後に変数");
-	{
-		t_parse_buffer	buf;
-		init_buf_with_string(&buf, T1016 "$deadbeef\n");
-		t_token	tok;
-
-		CHECK_EQ(strlen(T1016 "$deadbeef"), 1025);
-
-		lex_get_token(&buf, &tok);
-		CHECK_EQ(tok.length, 1016);
-		t_parse_ast *node = parse_command_line(&buf, &tok);
-		CHECK(node);
-		node = node->content.command_line->seqcmd_node
-			->content.sequential_commands
-			->pipcmd_node->content.piped_commands
-			->command_node->content.command
-			->arguments_node;
-		CHECK_EQ(node->type, ASTNODE_ARGUMENTS);
-		check_single_argument(node, T1016);
-
-		node = node->content.arguments->string_node;
-		CHECK_EQ(node->content.string->type, TOKTYPE_EXPANDABLE);
-		node = node->content.string->next;
-		CHECK_EQ(node->type, ASTNODE_STRING);
-		CHECK_EQ(node->content.string->type, TOKTYPE_EXPANDABLE);
-		check_string(node, "$deadbeef");
-	}
-
-	TEST_SECTION("parse_command_line ダブルクォートされた長い行");
-	{
-		t_parse_buffer	buf;
-		init_buf_with_string(&buf, "\"" T1280 "\"\n");
-		t_token	tok;
-
-		lex_get_token(&buf, &tok);
-		t_parse_ast *node = parse_command_line(&buf, &tok);
-		CHECK(node);
-
-		node = node->content.command_line->seqcmd_node
-			->content.sequential_commands
-			->pipcmd_node->content.piped_commands
-			->command_node->content.command
-			->arguments_node;
-		CHECK_EQ(node->type, ASTNODE_ARGUMENTS);
-		check_single_argument(node, T1024);
-
-		node = node->content.arguments->string_node;
-		CHECK_EQ(node->type, ASTNODE_STRING);
-		CHECK_EQ(node->content.string->type, TOKTYPE_EXPANDABLE_QUOTED);
-
-		// のこり
-		node = node->content.string->next;
-		CHECK_EQ(node->type, ASTNODE_STRING);
-		CHECK_EQ(node->content.string->type, TOKTYPE_EXPANDABLE_QUOTED);
-		check_string(node, T128 T128); /* 256 */
-	}
-
-	TEST_SECTION("parse_command_line ダブルクォートされた長い行の最後に変数");
-	{
-		t_parse_buffer	buf;
-		init_buf_with_string(&buf, "\"" T1016 "$deadbeef\"\n");
-		t_token	tok;
-
-		CHECK_EQ(strlen(T1016 "$deadbeef"), 1025);
-
-		lex_get_token(&buf, &tok);
-		CHECK_EQ(tok.length, 1016);
-		t_parse_ast *node = parse_command_line(&buf, &tok);
-		CHECK(node);
-		node = node->content.command_line->seqcmd_node
-			->content.sequential_commands
-			->pipcmd_node->content.piped_commands
-			->command_node->content.command
-			->arguments_node;
-		CHECK_EQ(node->type, ASTNODE_ARGUMENTS);
-		check_single_argument(node, T1016);
-
-		node = node->content.arguments->string_node;
-		CHECK_EQ(node->content.string->type, TOKTYPE_EXPANDABLE_QUOTED);
-		node = node->content.string->next;
-		CHECK_EQ(node->type, ASTNODE_STRING);
-		CHECK_EQ(node->content.string->type, TOKTYPE_EXPANDABLE_QUOTED);
-		check_string(node, "$deadbeef");
-	}
-
-	TEST_SECTION("parse_command_line シングルクォートされた長い行");
-	{
-		t_parse_buffer	buf;
-		init_buf_with_string(&buf, "'" T1280 "'\n");
-		t_token	tok;
-
-		lex_get_token(&buf, &tok);
-		t_parse_ast *node = parse_command_line(&buf, &tok);
-		CHECK(node);
-
-		node = node->content.command_line->seqcmd_node
-			->content.sequential_commands
-			->pipcmd_node->content.piped_commands
-			->command_node->content.command
-			->arguments_node;
-		CHECK_EQ(node->type, ASTNODE_ARGUMENTS);
-		check_single_argument(node, T1024);
-
-		node = node->content.arguments->string_node;
-		CHECK_EQ(node->type, ASTNODE_STRING);
-		CHECK_EQ(node->content.string->type, TOKTYPE_NON_EXPANDABLE);
-
-		// のこり
-		node = node->content.string->next;
-		CHECK_EQ(node->type, ASTNODE_STRING);
-		CHECK_EQ(node->content.string->type, TOKTYPE_NON_EXPANDABLE);
-		check_string(node, T128 T128); /* 256 */
+		free(tok.text);
 	}
 
 	TEST_SECTION("parse_command_line > のあとにファイル名が続かないときはエラー");
@@ -1158,10 +1093,12 @@ void test_parser(void)
 		t_parse_buffer	buf;
 		init_buf_with_string(&buf, "aho >\n");
 		t_token	tok;
+		lex_init_token(&tok);
 
 		lex_get_token(&buf, &tok);
 		t_parse_ast *node = parse_command_line(&buf, &tok);
 		CHECK(!node);
+		free(tok.text);
 	}
 
 	TEST_SECTION("parse_command_line > のあとに ; はエラー");
@@ -1169,10 +1106,12 @@ void test_parser(void)
 		t_parse_buffer	buf;
 		init_buf_with_string(&buf, "aho >; boke\n");
 		t_token	tok;
+		lex_init_token(&tok);
 
 		lex_get_token(&buf, &tok);
 		t_parse_ast *node = parse_command_line(&buf, &tok);
 		CHECK(!node);
+		free(tok.text);
 	}
 
 	TEST_SECTION("parse_command_line | のあとにコマンドが続かないときはエラー");
@@ -1180,10 +1119,12 @@ void test_parser(void)
 		t_parse_buffer	buf;
 		init_buf_with_string(&buf, "aho |\n");
 		t_token	tok;
+		lex_init_token(&tok);
 
 		lex_get_token(&buf, &tok);
 		t_parse_ast *node = parse_command_line(&buf, &tok);
 		CHECK(!node);
+		free(tok.text);
 	}
 
 	TEST_SECTION("parse_command_line | のあとに ; はエラー");
@@ -1191,12 +1132,13 @@ void test_parser(void)
 		t_parse_buffer	buf;
 		init_buf_with_string(&buf, "aho |; boke\n");
 		t_token	tok;
+		lex_init_token(&tok);
 
 		lex_get_token(&buf, &tok);
 		t_parse_ast *node = parse_command_line(&buf, &tok);
 		CHECK(!node);
+		free(tok.text);
 	}
-
 
 }
 


### PR DESCRIPTION
`TOKEN_BUFFER_SIZE`(1024) を超えるとトークンを区切っていたのを区切らないようにした.

これにより長い環境変数(1024文字超え)でも問題なく動作するようになった.