### PR TITLE
コマンド実行部分でのheredocの実装

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,8 +33,8 @@ SRCS = cmd_cmd_invocation.c cmd_cmd_invocation2.c cmd_exec_command.c		\
 	path.c g_cwd.c string_node2string.c env_expander.c heredoc_expander.c	\
 	expand_string_node.c split_expanded_str.c t_var.c t_var2.c				\
 																			\
-	builtin.c builtin_echo.c builtin_env.c builtin_exit.c builtin_cd.c		\
-	builtin_cd_path.c builtin_cd_chdir.c builtin_cd_cdpath.c				\
+	builtin.c builtin_fd_list.c builtin_echo.c builtin_env.c builtin_exit.c	\
+	builtin_cd.c builtin_cd_path.c builtin_cd_chdir.c builtin_cd_cdpath.c	\
 	builtin_export.c builtin_export2.c builtin_pwd.c builtin_unset.c		\
 																			\
 	str_utils.c shell_initialization.c minishell.c	interactive_shell.c

--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,8 @@ HEADER_FILES = builtin.h env.h lexer.h parse.h	\
 	execution.h minishell.h path.h utils.h
 
 SRCS = cmd_cmd_invocation.c cmd_cmd_invocation2.c cmd_exec_command.c		\
-	cmd_exec_commands.c cmd_pipe.c cmd_redirection.c convert_ast2cmdinvo.c	\
+	cmd_exec_commands.c cmd_pipe.c cmd_redirection.c cmd_heredoc_funcs.c	\
+	convert_ast2cmdinvo.c													\
 	cmd_status.c signal.c env_setter.c minishell_error_msg.c env.c exec.c	\
 	cmd_exec_builtin.c														\
 																			\

--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ SRCS = cmd_cmd_invocation.c cmd_cmd_invocation2.c cmd_exec_command.c		\
 	lexer1.c lexer2.c lexer3.c lexer4.c parse1.c parse2.c parse3.c			\
 	parse_utils.c parse_utils2.c											\
 																			\
-	path.c g_cwd.c string_node2string.c expand_env_var.c					\
+	path.c g_cwd.c string_node2string.c env_expander.c heredoc_expander.c	\
 	expand_string_node.c split_expanded_str.c t_var.c t_var2.c				\
 																			\
 	builtin.c builtin_echo.c builtin_env.c builtin_exit.c builtin_cd.c		\

--- a/builtin_exit.c
+++ b/builtin_exit.c
@@ -9,8 +9,7 @@ static void	put_exit_errmsg_and_exit(char *exit_status)
 	char	*tmp;
 
 	tmp = ft_strjoin(exit_status, ": numeric argument required");
-	if (!tmp)
-		put_minish_err_msg_and_exit(2, "exit", "ft_strjoin() failed");
+	check_malloc_has_succeeded("exit", tmp);
 	put_minish_err_msg_and_exit(2, "exit", tmp);
 }
 

--- a/builtin_export.c
+++ b/builtin_export.c
@@ -13,12 +13,10 @@ static void	put_export_err_msg(char *identifer)
 	char	*errmsg;
 
 	tmp = ft_strjoin("`", identifer);
-	if (!tmp)
-		put_minish_err_msg_and_exit(1, "export", "failed malloc()");
+	check_malloc_has_succeeded("export", tmp);
 	errmsg = ft_strjoin(tmp, "': not a valid identifier");
 	free(tmp);
-	if (!errmsg)
-		put_minish_err_msg_and_exit(1, "export", "failed malloc()");
+	check_malloc_has_succeeded("export", errmsg);
 	put_minish_err_msg("export", errmsg);
 	free(errmsg);
 }

--- a/builtin_fd_list.c
+++ b/builtin_fd_list.c
@@ -1,0 +1,51 @@
+#include <unistd.h>
+#include <sys/wait.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+#include <string.h>
+#include <errno.h>
+#include "env.h"
+#include "execution.h"
+#include "builtin.h"
+
+t_fd_list	*fd_list_add_fd(t_fd_list **lst, int fd)
+{
+	t_fd_list	*new_lst;
+	t_fd_list	*tmp;
+
+	if (!lst)
+		return (NULL);
+	new_lst = ft_calloc(1, sizeof(t_fd_list));
+	new_lst->fd = fd;
+	if (!new_lst)
+		return (NULL);
+	if (!*lst)
+		*lst = new_lst;
+	else
+	{
+		tmp = *lst;
+		while (tmp->next)
+			tmp = tmp->next;
+		tmp->next = new_lst;
+	}
+	return (new_lst);
+}
+
+void	fd_list_close(t_fd_list **lst)
+{
+	t_fd_list	*current;
+	t_fd_list	*tmp;
+
+	if (!lst)
+		return ;
+	current = *lst;
+	while (current)
+	{
+		close(current->fd);
+		tmp = current;
+		current = current->next;
+		free(tmp);
+	}
+	*lst = NULL;
+}

--- a/cmd_cmd_invocation.c
+++ b/cmd_cmd_invocation.c
@@ -1,5 +1,9 @@
+#include <stdio.h>
+#include <readline/readline.h>
+#include <readline/history.h>
 #include "execution.h"
 #include "minishell.h"
+#include "utils.h"
 
 /*
 ** Malloc and initialize t_command_invocation
@@ -39,12 +43,24 @@ int	cmd_add_inredirect(t_command_invocation *command,
 int	cmd_add_heredoc(t_command_invocation *command,
 	const char *limit_str, int fd)
 {
+	char	*input_str;
 	t_cmd_redirection	*redirection;
 
 	redirection = ft_calloc(1, sizeof(t_cmd_redirection));
 	redirection->fd = fd;
 	redirection->is_heredoc = true;
 	// TODO: 標準入力からデータ読み込み
+	while (1)
+	{
+		input_str = readline("> ");
+		printf("input_str: |%s|\n", input_str);
+		if (!input_str)
+			return (put_minish_err_msg_and_ret(ERROR, "heredoc", "delimited by EOF"));
+		if (!ft_strcmp(input_str, limit_str))
+			break ;
+		redirection->filepath = strjoin_nullable_and_free_both(
+			(char *)redirection->filepath, input_str);
+	}
 	if (!redirection || !ft_lstadd_back_new(
 			&command->input_redirections, (void *)redirection))
 		put_minish_err_msg_and_exit(1, "redirection", "malloc failed");
@@ -63,7 +79,6 @@ int	cmd_add_outredirect(t_command_invocation *command,
 	if (!redirection || !ft_lstadd_back_new(
 			&command->output_redirections, (void *)redirection))
 	{
-		// TODO: malloc() 失敗時にはexit()する
 		free(redirection);
 		return (ERROR);
 	}

--- a/cmd_cmd_invocation.c
+++ b/cmd_cmd_invocation.c
@@ -1,4 +1,5 @@
 #include "execution.h"
+#include "minishell.h"
 
 /*
 ** Malloc and initialize t_command_invocation
@@ -35,6 +36,21 @@ int	cmd_add_inredirect(t_command_invocation *command,
 	return (0);
 }
 
+int	cmd_add_heredoc(t_command_invocation *command,
+	const char *limit_str, int fd)
+{
+	t_cmd_redirection	*redirection;
+
+	redirection = ft_calloc(1, sizeof(t_cmd_redirection));
+	redirection->fd = fd;
+	redirection->is_heredoc = true;
+	// TODO: 標準入力からデータ読み込み
+	if (!redirection || !ft_lstadd_back_new(
+			&command->input_redirections, (void *)redirection))
+		put_minish_err_msg_and_exit(1, "redirection", "malloc failed");
+	return (0);
+}
+
 int	cmd_add_outredirect(t_command_invocation *command,
 	const char *filepath, int fd, bool is_append)
 {
@@ -47,6 +63,7 @@ int	cmd_add_outredirect(t_command_invocation *command,
 	if (!redirection || !ft_lstadd_back_new(
 			&command->output_redirections, (void *)redirection))
 	{
+		// TODO: malloc() 失敗時にはexit()する
 		free(redirection);
 		return (ERROR);
 	}

--- a/cmd_cmd_invocation.c
+++ b/cmd_cmd_invocation.c
@@ -44,30 +44,6 @@ int	cmd_add_inredirect(t_command_invocation *command,
 	return (0);
 }
 
-static int	done_readline(void)
-{
-	if (g_shell.heredoc_interruption)
-		rl_done = 1;
-	return 0;
-}
-
-static void	heredoc_sigint_sighandler(int sig)
-{
-	g_shell.heredoc_interruption = 1;
-	set_status(128 + sig);
-}
-
-void	set_heredoc_sighandlers()
-{
-	g_shell.heredoc_interruption = 0;
-	if (signal(SIGQUIT, SIG_IGN) == SIG_ERR
-		|| signal(SIGINT, heredoc_sigint_sighandler) == SIG_ERR)
-	{
-		printf("signal() failed\n");
-		exit(1);
-	}
-}
-
 int	cmd_add_heredoc(t_command_invocation *command,
 	const char *limit_str, int fd)
 {
@@ -80,8 +56,8 @@ int	cmd_add_heredoc(t_command_invocation *command,
 		put_minish_err_msg_and_exit(1, "heredoc", "malloc failed");
 	redirection->fd = fd;
 	redirection->is_heredoc = true;
-	set_heredoc_sighandlers();
-	rl_event_hook = done_readline;
+	cmd_set_heredoc_sighandlers();
+	rl_event_hook = cmd_check_readline_has_finished;
 	while (!g_shell.heredoc_interruption)
 	{
 		input_str = readline("> ");

--- a/cmd_cmd_invocation.c
+++ b/cmd_cmd_invocation.c
@@ -81,9 +81,12 @@ int	cmd_add_heredoc(t_command_invocation *command,
 	if (!input_str)
 		write(1, "\n", 1);
 	free(input_str);
-	old_filepath = redirection->filepath;
-	redirection->filepath = expand_env_var((char *)redirection->filepath);
-	free((void*)old_filepath);
+	if (is_expandable)
+	{
+		old_filepath = redirection->filepath;
+		redirection->filepath = expand_heredoc_document((char *)redirection->filepath);
+		free((void*)old_filepath);
+	}
 	if (!ft_lstadd_back_new(
 			&command->input_redirections, (void *)redirection))
 		put_minish_err_msg_and_exit(1, "heredoc", "lstadd_back failed");

--- a/cmd_cmd_invocation.c
+++ b/cmd_cmd_invocation.c
@@ -54,9 +54,7 @@ int	cmd_add_heredoc(t_command_invocation *command,
 	while (1)
 	{
 		input_str = readline("> ");
-		if (!input_str)
-			return (put_minish_err_msg_and_ret(ERROR, "heredoc", "delimited by EOF"));
-		if (!ft_strcmp(input_str, limit_str))
+		if (!input_str || !ft_strcmp(input_str, limit_str))
 			break ;
 		redirection->filepath = strjoin_nullable_and_free_both(
 			(char *)redirection->filepath, input_str);
@@ -67,6 +65,8 @@ int	cmd_add_heredoc(t_command_invocation *command,
 		if (!redirection->filepath)
 			return (ERROR);
 	}
+	if (!input_str)
+		write(1, "\n", 1);
 	if (!ft_lstadd_back_new(
 			&command->input_redirections, (void *)redirection))
 		put_minish_err_msg_and_exit(1, "redirection", "lstadd_back failed");

--- a/cmd_cmd_invocation.c
+++ b/cmd_cmd_invocation.c
@@ -52,7 +52,6 @@ int	cmd_add_heredoc(t_command_invocation *command,
 	while (1)
 	{
 		input_str = readline("> ");
-		printf("input_str: |%s|\n", input_str);
 		if (!input_str)
 			return (put_minish_err_msg_and_ret(ERROR, "heredoc", "delimited by EOF"));
 		if (!ft_strcmp(input_str, limit_str))

--- a/cmd_cmd_invocation.c
+++ b/cmd_cmd_invocation.c
@@ -47,8 +47,9 @@ int	cmd_add_inredirect(t_command_invocation *command,
 int	cmd_add_heredoc(t_command_invocation *command,
 	const char *limit_str, int fd)
 {
-	char	*input_str;
+	char				*input_str;
 	t_cmd_redirection	*redirection;
+	const char			*old_filepath;
 
 	redirection = ft_calloc(1, sizeof(t_cmd_redirection));
 	if (!redirection)
@@ -72,6 +73,9 @@ int	cmd_add_heredoc(t_command_invocation *command,
 	if (!input_str)
 		write(1, "\n", 1);
 	free(input_str);
+	old_filepath = redirection->filepath;
+	redirection->filepath = expand_env_var((char *)redirection->filepath);
+	free((void*)old_filepath);
 	if (!ft_lstadd_back_new(
 			&command->input_redirections, (void *)redirection))
 		put_minish_err_msg_and_exit(1, "heredoc", "lstadd_back failed");

--- a/cmd_cmd_invocation.c
+++ b/cmd_cmd_invocation.c
@@ -45,7 +45,7 @@ int	cmd_add_inredirect(t_command_invocation *command,
 }
 
 int	cmd_add_heredoc(t_command_invocation *command,
-	const char *limit_str, int fd)
+	const char *limit_str, int fd, bool is_expandable)
 {
 	char				*input_str;
 	t_cmd_redirection	*redirection;

--- a/cmd_cmd_invocation.c
+++ b/cmd_cmd_invocation.c
@@ -29,9 +29,13 @@ int	cmd_add_inredirect(t_command_invocation *command,
 	t_cmd_redirection	*redirection;
 
 	redirection = ft_calloc(1, sizeof(t_cmd_redirection));
-	redirection->filepath = filepath;
+	if (!redirection)
+		put_minish_err_msg_and_exit(1, "add_inredirect", "malloc() failed");
+	redirection->filepath = ft_strdup(filepath);
+	if (!redirection->filepath)
+		put_minish_err_msg_and_exit(1, "add_inredirect", "malloc() failed");
 	redirection->fd = fd;
-	if (!redirection || !ft_lstadd_back_new(
+	if (!ft_lstadd_back_new(
 			&command->input_redirections, (void *)redirection))
 	{
 		free(redirection);
@@ -48,7 +52,7 @@ int	cmd_add_heredoc(t_command_invocation *command,
 
 	redirection = ft_calloc(1, sizeof(t_cmd_redirection));
 	if (!redirection)
-		put_minish_err_msg_and_exit(1, "redirection", "malloc failed");
+		put_minish_err_msg_and_exit(1, "heredoc", "malloc failed");
 	redirection->fd = fd;
 	redirection->is_heredoc = true;
 	while (1)
@@ -67,9 +71,10 @@ int	cmd_add_heredoc(t_command_invocation *command,
 	}
 	if (!input_str)
 		write(1, "\n", 1);
+	free(input_str);
 	if (!ft_lstadd_back_new(
 			&command->input_redirections, (void *)redirection))
-		put_minish_err_msg_and_exit(1, "redirection", "lstadd_back failed");
+		put_minish_err_msg_and_exit(1, "heredoc", "lstadd_back failed");
 	return (0);
 }
 
@@ -79,10 +84,14 @@ int	cmd_add_outredirect(t_command_invocation *command,
 	t_cmd_redirection	*redirection;
 
 	redirection = ft_calloc(1, sizeof(t_cmd_redirection));
-	redirection->filepath = filepath;
+	if (!redirection)
+		put_minish_err_msg_and_exit(1, "add_outredirect", "malloc() failed");
+	redirection->filepath = ft_strdup(filepath);
+	if (!redirection->filepath)
+		put_minish_err_msg_and_exit(1, "add_outredirect", "malloc() failed");
 	redirection->fd = fd;
 	redirection->is_append = is_append;
-	if (!redirection || !ft_lstadd_back_new(
+	if (ft_lstadd_back_new(
 			&command->output_redirections, (void *)redirection))
 	{
 		free(redirection);

--- a/cmd_cmd_invocation.c
+++ b/cmd_cmd_invocation.c
@@ -47,6 +47,8 @@ int	cmd_add_heredoc(t_command_invocation *command,
 	t_cmd_redirection	*redirection;
 
 	redirection = ft_calloc(1, sizeof(t_cmd_redirection));
+	if (!redirection)
+		put_minish_err_msg_and_exit(1, "redirection", "malloc failed");
 	redirection->fd = fd;
 	redirection->is_heredoc = true;
 	while (1)
@@ -58,12 +60,16 @@ int	cmd_add_heredoc(t_command_invocation *command,
 			break ;
 		redirection->filepath = strjoin_nullable_and_free_both(
 			(char *)redirection->filepath, input_str);
+		if (!redirection->filepath)
+			return (ERROR);
 		redirection->filepath = strjoin_and_free_first(
 			(char *)redirection->filepath, "\n");
+		if (!redirection->filepath)
+			return (ERROR);
 	}
-	if (!redirection || !ft_lstadd_back_new(
+	if (!ft_lstadd_back_new(
 			&command->input_redirections, (void *)redirection))
-		put_minish_err_msg_and_exit(1, "redirection", "malloc failed");
+		put_minish_err_msg_and_exit(1, "redirection", "lstadd_back failed");
 	return (0);
 }
 

--- a/cmd_cmd_invocation.c
+++ b/cmd_cmd_invocation.c
@@ -44,56 +44,6 @@ int	cmd_add_inredirect(t_command_invocation *command,
 	return (0);
 }
 
-int	cmd_add_heredoc(t_command_invocation *command,
-	const char *limit_str, int fd, bool is_expandable)
-{
-	char				*input_str;
-	t_cmd_redirection	*redirection;
-	const char			*old_filepath;
-
-	redirection = ft_calloc(1, sizeof(t_cmd_redirection));
-	if (!redirection)
-		put_minish_err_msg_and_exit(1, "heredoc", "malloc failed");
-	redirection->fd = fd;
-	redirection->is_heredoc = true;
-	cmd_set_heredoc_sighandlers();
-	rl_event_hook = cmd_check_readline_has_finished;
-	while (!g_shell.heredoc_interruption)
-	{
-		input_str = readline("> ");
-		if (!input_str || !ft_strcmp(input_str, limit_str))
-			break ;
-		redirection->filepath = strjoin_nullable_and_free_both(
-			(char *)redirection->filepath, input_str);
-		if (!redirection->filepath)
-			put_minish_err_msg_and_exit(1, "heredoc", "strjoin failed");
-		redirection->filepath = strjoin_and_free_first(
-			(char *)redirection->filepath, "\n");
-		if (!redirection->filepath)
-			put_minish_err_msg_and_exit(1, "heredoc", "strjoin failed");
-	}
-	rl_event_hook = NULL;
-	if (g_shell.heredoc_interruption)
-	{
-		cmd_del_redirection(redirection);
-		return (ERROR);
-	}
-	if (!input_str)
-		write(1, "\n", 1);
-	free(input_str);
-	if (is_expandable)
-	{
-		old_filepath = redirection->filepath;
-		redirection->filepath = expand_heredoc_document((char *)redirection->filepath);
-		free((void*)old_filepath);
-	}
-	if (!ft_lstadd_back_new(
-			&command->input_redirections, (void *)redirection))
-		put_minish_err_msg_and_exit(1, "heredoc", "lstadd_back failed");
-	set_sighandlers_during_execution();
-	return (0);
-}
-
 int	cmd_add_outredirect(t_command_invocation *command,
 	const char *filepath, int fd, bool is_append)
 {

--- a/cmd_cmd_invocation.c
+++ b/cmd_cmd_invocation.c
@@ -18,9 +18,6 @@ t_command_invocation	*cmd_init_cmdinvo(const char **exec_and_args)
 	return (cmdinvo);
 }
 
-/*
- * add input redirection
- */
 int	cmd_add_inredirect(t_command_invocation *command,
 	const char *filepath, int fd)
 {
@@ -38,9 +35,6 @@ int	cmd_add_inredirect(t_command_invocation *command,
 	return (0);
 }
 
-/*
- * add output redirection
- */
 int	cmd_add_outredirect(t_command_invocation *command,
 	const char *filepath, int fd, bool is_append)
 {

--- a/cmd_cmd_invocation.c
+++ b/cmd_cmd_invocation.c
@@ -26,19 +26,17 @@ t_command_invocation	*cmd_init_cmdinvo(const char **exec_and_args)
 int	cmd_add_inredirect(t_command_invocation *command,
 	const char *filepath, int fd)
 {
-	t_cmd_redirection	*redirection;
+	t_cmd_redirection	*red;
 
-	redirection = ft_calloc(1, sizeof(t_cmd_redirection));
-	if (!redirection)
-		put_minish_err_msg_and_exit(1, "add_inredirect", "malloc() failed");
-	redirection->filepath = ft_strdup(filepath);
-	if (!redirection->filepath)
-		put_minish_err_msg_and_exit(1, "add_inredirect", "malloc() failed");
-	redirection->fd = fd;
+	red = ft_calloc(1, sizeof(t_cmd_redirection));
+	check_malloc_has_succeeded("add_inredirect", red);
+	red->filepath = ft_strdup(filepath);
+	check_malloc_has_succeeded("add_inredirect", (void *)red->filepath);
+	red->fd = fd;
 	if (!ft_lstadd_back_new(
-			&command->input_redirections, (void *)redirection))
+			&command->input_redirections, (void *)red))
 	{
-		free(redirection);
+		free(red);
 		return (ERROR);
 	}
 	return (0);
@@ -47,20 +45,18 @@ int	cmd_add_inredirect(t_command_invocation *command,
 int	cmd_add_outredirect(t_command_invocation *command,
 	const char *filepath, int fd, bool is_append)
 {
-	t_cmd_redirection	*redirection;
+	t_cmd_redirection	*red;
 
-	redirection = ft_calloc(1, sizeof(t_cmd_redirection));
-	if (!redirection)
-		put_minish_err_msg_and_exit(1, "add_outredirect", "malloc() failed");
-	redirection->filepath = ft_strdup(filepath);
-	if (!redirection->filepath)
-		put_minish_err_msg_and_exit(1, "add_outredirect", "malloc() failed");
-	redirection->fd = fd;
-	redirection->is_append = is_append;
+	red = ft_calloc(1, sizeof(t_cmd_redirection));
+	check_malloc_has_succeeded("add_outredirect", red);
+	red->filepath = ft_strdup(filepath);
+	check_malloc_has_succeeded("add_outredirect", (void *)red->filepath);
+	red->fd = fd;
+	red->is_append = is_append;
 	if (!ft_lstadd_back_new(
-			&command->output_redirections, (void *)redirection))
+			&command->output_redirections, (void *)red))
 	{
-		free(redirection);
+		free(red);
 		return (ERROR);
 	}
 	return (0);

--- a/cmd_cmd_invocation.c
+++ b/cmd_cmd_invocation.c
@@ -49,7 +49,6 @@ int	cmd_add_heredoc(t_command_invocation *command,
 	redirection = ft_calloc(1, sizeof(t_cmd_redirection));
 	redirection->fd = fd;
 	redirection->is_heredoc = true;
-	// TODO: 標準入力からデータ読み込み
 	while (1)
 	{
 		input_str = readline("> ");
@@ -60,6 +59,8 @@ int	cmd_add_heredoc(t_command_invocation *command,
 			break ;
 		redirection->filepath = strjoin_nullable_and_free_both(
 			(char *)redirection->filepath, input_str);
+		redirection->filepath = strjoin_and_free_first(
+			(char *)redirection->filepath, "\n");
 	}
 	if (!redirection || !ft_lstadd_back_new(
 			&command->input_redirections, (void *)redirection))

--- a/cmd_cmd_invocation.c
+++ b/cmd_cmd_invocation.c
@@ -104,7 +104,7 @@ int	cmd_add_outredirect(t_command_invocation *command,
 		put_minish_err_msg_and_exit(1, "add_outredirect", "malloc() failed");
 	redirection->fd = fd;
 	redirection->is_append = is_append;
-	if (ft_lstadd_back_new(
+	if (!ft_lstadd_back_new(
 			&command->output_redirections, (void *)redirection))
 	{
 		free(redirection);

--- a/cmd_cmd_invocation2.c
+++ b/cmd_cmd_invocation2.c
@@ -57,13 +57,9 @@ static void	readline4heredoc(t_cmd_redirection *red, const char *limit_str)
 		red->filepath = strjoin_nullable_and_free_both(
 				(char *)red->filepath, input_str);
 		check_malloc_has_succeeded("heredoc", (void *)red->filepath);
-		if (!red->filepath)
-			put_minish_err_msg_and_exit(1, "heredoc", "strjoin failed");
 		red->filepath = strjoin_and_free_first(
 				(char *)red->filepath, "\n");
 		check_malloc_has_succeeded("heredoc", (void *)red->filepath);
-		if (!red->filepath)
-			put_minish_err_msg_and_exit(1, "heredoc", "strjoin failed");
 	}
 	rl_event_hook = NULL;
 	if (!input_str)
@@ -78,8 +74,7 @@ int	cmd_add_heredoc(t_command_invocation *command,
 	const char			*old_filepath;
 
 	red = ft_calloc(1, sizeof(t_cmd_redirection));
-	if (!red)
-		put_minish_err_msg_and_exit(1, "heredoc", "malloc failed");
+	check_malloc_has_succeeded("heredoc", (void *)red);
 	red->fd = fd;
 	red->is_heredoc = true;
 	cmd_set_heredoc_sighandlers();

--- a/cmd_cmd_invocation2.c
+++ b/cmd_cmd_invocation2.c
@@ -63,8 +63,10 @@ static void	readline4heredoc(t_cmd_redirection *red, const char *limit_str)
 	}
 	rl_event_hook = NULL;
 	if (!input_str)
+	{
 		write(1, "\n", 1);
-	free(input_str);
+		free(input_str);
+	}
 }
 
 int	cmd_add_heredoc(t_command_invocation *command,

--- a/cmd_cmd_invocation2.c
+++ b/cmd_cmd_invocation2.c
@@ -62,11 +62,10 @@ static void	readline4heredoc(t_cmd_redirection *red, const char *limit_str)
 		check_malloc_has_succeeded("heredoc", (void *)red->filepath);
 	}
 	rl_event_hook = NULL;
-	if (!input_str)
-	{
-		write(1, "\n", 1);
+	if (input_str)
 		free(input_str);
-	}
+	else
+		write(1, "\n", 1);
 }
 
 int	cmd_add_heredoc(t_command_invocation *command,

--- a/cmd_cmd_invocation2.c
+++ b/cmd_cmd_invocation2.c
@@ -1,4 +1,9 @@
+#include <stdio.h>
+#include <readline/readline.h>
+#include <readline/history.h>
+#include "minishell.h"
 #include "execution.h"
+#include "utils.h"
 
 /*
  * free redirection->filepath and redirection object.
@@ -37,4 +42,61 @@ void	cmd_free_cmdinvo(t_command_invocation *cmds)
 			free(prev_cmd);
 		}
 	}
+}
+
+static void	readline4heredoc(t_cmd_redirection *red, const char *limit_str)
+{
+	char	*input_str;
+
+	rl_event_hook = cmd_check_readline_has_finished;
+	while (!g_shell.heredoc_interruption)
+	{
+		input_str = readline("> ");
+		if (!input_str || !ft_strcmp(input_str, limit_str))
+			break ;
+		red->filepath = strjoin_nullable_and_free_both(
+				(char *)red->filepath, input_str);
+		check_malloc_has_succeeded("heredoc", (void *)red->filepath);
+		if (!red->filepath)
+			put_minish_err_msg_and_exit(1, "heredoc", "strjoin failed");
+		red->filepath = strjoin_and_free_first(
+				(char *)red->filepath, "\n");
+		check_malloc_has_succeeded("heredoc", (void *)red->filepath);
+		if (!red->filepath)
+			put_minish_err_msg_and_exit(1, "heredoc", "strjoin failed");
+	}
+	rl_event_hook = NULL;
+	if (!input_str)
+		write(1, "\n", 1);
+	free(input_str);
+}
+
+int	cmd_add_heredoc(t_command_invocation *command,
+	const char *limit_str, int fd, bool is_expandable)
+{
+	t_cmd_redirection	*red;
+	const char			*old_filepath;
+
+	red = ft_calloc(1, sizeof(t_cmd_redirection));
+	if (!red)
+		put_minish_err_msg_and_exit(1, "heredoc", "malloc failed");
+	red->fd = fd;
+	red->is_heredoc = true;
+	cmd_set_heredoc_sighandlers();
+	readline4heredoc(red, limit_str);
+	if (g_shell.heredoc_interruption)
+	{
+		cmd_del_redirection(red);
+		return (ERROR);
+	}
+	if (is_expandable)
+	{
+		old_filepath = red->filepath;
+		red->filepath = expand_heredoc_document((char *)red->filepath);
+		free((void *)old_filepath);
+	}
+	if (!ft_lstadd_back_new(&command->input_redirections, (void *)red))
+		put_minish_err_msg_and_exit(1, "heredoc", "lstadd_back failed");
+	set_sighandlers_during_execution();
+	return (0);
 }

--- a/cmd_exec_builtin.c
+++ b/cmd_exec_builtin.c
@@ -83,7 +83,7 @@ static int	builtin_set_in_red(t_command_invocation *command,
 				*stdoutfd = dup(*stdoutfd);
 			if  (dup2(fd, red->fd) == ERROR || close(fd) == ERROR
 				|| !fd_list_add_fd(fd_list, red->fd))
-				return (put_redirect_fd_err_msg_and_ret(ERROR,
+				return (put_redir_errmsg_and_ret(ERROR,
 						red->fd, strerror(errno)));
 		}
 		else
@@ -131,7 +131,7 @@ static int	builtin_set_out_red(t_command_invocation *command,
 			*stdoutfd = dup(*stdoutfd);
 		if (dup2(fd, red->fd) == ERROR || close(fd) == ERROR
 			|| !fd_list_add_fd(fd_list, red->fd))
-			return (put_redirect_fd_err_msg_and_ret(ERROR,
+			return (put_redir_errmsg_and_ret(ERROR,
 					red->fd, strerror(errno)));
 		current = current->next;
 	}

--- a/cmd_exec_builtin.c
+++ b/cmd_exec_builtin.c
@@ -10,47 +10,6 @@
 #include "builtin.h"
 #include "minishell.h"
 
-t_fd_list	*fd_list_add_fd(t_fd_list **lst, int fd)
-{
-	t_fd_list	*new_lst;
-	t_fd_list	*tmp;
-
-	if (!lst)
-		return (NULL);
-	new_lst = ft_calloc(1, sizeof(t_fd_list));
-	new_lst->fd = fd;
-	if (!new_lst)
-		return (NULL);
-	if (!*lst)
-		*lst = new_lst;
-	else
-	{
-		tmp = *lst;
-		while (tmp->next)
-			tmp = tmp->next;
-		tmp->next = new_lst;
-	}
-	return (new_lst);
-}
-
-void	fd_list_close(t_fd_list **lst)
-{
-	t_fd_list	*current;
-	t_fd_list	*tmp;
-
-	if (!lst)
-		return ;
-	current = *lst;
-	while (current)
-	{
-		close(current->fd);
-		tmp = current;
-		current = current->next;
-		free(tmp);
-	}
-	*lst = NULL;
-}
-
 /* Configure input redirection for builtin command.
  *
  * command: Command.
@@ -81,7 +40,7 @@ static int	builtin_set_in_red(t_command_invocation *command,
 				*stdinfd = dup(*stdinfd);
 			if (red->fd == *stdoutfd)
 				*stdoutfd = dup(*stdoutfd);
-			if  (dup2(fd, red->fd) == ERROR || close(fd) == ERROR
+			if (dup2(fd, red->fd) == ERROR || close(fd) == ERROR
 				|| !fd_list_add_fd(fd_list, red->fd))
 				return (put_redir_errmsg_and_ret(ERROR,
 						red->fd, strerror(errno)));

--- a/cmd_exec_command.c
+++ b/cmd_exec_command.c
@@ -1,4 +1,5 @@
 #include <unistd.h>
+#include "execution.h"
 #include "minishell.h"
 #include "builtin.h"
 #include "libft/libft.h"
@@ -15,14 +16,14 @@ static void	replace_stdio_with_pipe(t_command_invocation *command,
 	{
 		close(pipe_prev_fd[1]);
 		if (dup2(pipe_prev_fd[0], STDIN_FILENO) == -1)
-			put_err_msg_and_exit("error child dup2()");
+			put_err_msg_and_exit("error child dup2(in)");
 		close(pipe_prev_fd[0]);
 	}
 	if (command->piped_command)
 	{
 		close(pipe_fd[0]);
 		if (dup2(pipe_fd[1], STDOUT_FILENO) == -1)
-			put_err_msg_and_exit("error child dup2()");
+			put_err_msg_and_exit("error child dup2(out)");
 		close(pipe_fd[1]);
 	}
 }
@@ -36,13 +37,13 @@ static void	replace_stdio_with_pipe(t_command_invocation *command,
  * pipe_fd[2]: A pipe that connects the current and next process.
  */
 void	cmd_exec_command(t_command_invocation *command,
-	int pipe_prev_fd[2], int pipe_fd[2])
+	int pipe_prev_fd[2], int pipe_fd[2], int pipe_heredoc_fd[2])
 {
 	t_builtin_cmd	*builtin_func;
 
 	set_sighandlers(SIG_DFL);
 	replace_stdio_with_pipe(command, pipe_prev_fd, pipe_fd);
-	if (cmd_set_input_file(command) == ERROR
+	if (cmd_set_input_file(command, pipe_heredoc_fd) == ERROR
 		|| cmd_set_output_file(command) == ERROR)
 		exit(EXIT_FAILURE);
 	if (!command->exec_and_args)

--- a/cmd_exec_commands.c
+++ b/cmd_exec_commands.c
@@ -51,7 +51,8 @@ int	write_heredoc(t_command_invocation *command, int pipe_heredoc_fd[2])
 	if (!red->is_heredoc)
 		return (0);
 	close(pipe_heredoc_fd[0]);
-	write(pipe_heredoc_fd[1], red->filepath, ft_strlen(red->filepath));
+	if (red->filepath)
+		write(pipe_heredoc_fd[1], red->filepath, ft_strlen(red->filepath));
 	return (0);
 }
 

--- a/cmd_exec_commands.c
+++ b/cmd_exec_commands.c
@@ -33,12 +33,11 @@ int	cmd_wait_commands(t_command_invocation *command)
 	return (status);
 }
 
-#include <stdio.h>
 /*
  * input_redirectionsの最後がheredocの場合, pipe_prev_fd(pipe_fd[1]) に書き込みを行う
  * pipe_fd: commandプロセスに対するpipe_fd
  */
-int	write_heredoc(t_command_invocation *command, int pipe_prev_fd[2])
+int	write_heredoc(t_command_invocation *command, int pipe_heredoc_fd[2])
 {
 	t_list				*current;
 	t_cmd_redirection	*red;
@@ -51,9 +50,8 @@ int	write_heredoc(t_command_invocation *command, int pipe_prev_fd[2])
 	red = (t_cmd_redirection *)current->content;
 	if (!red->is_heredoc)
 		return (0);
-	printf("----- write(%d) -----\n", pipe_prev_fd[1]);
-	printf("file_path: \n|%s|\n", red->filepath);
-	write(pipe_prev_fd[1], red->filepath, ft_strlen(red->filepath));
+	close(pipe_heredoc_fd[0]);
+	write(pipe_heredoc_fd[1], red->filepath, ft_strlen(red->filepath));
 	return (0);
 }
 

--- a/cmd_exec_commands.c
+++ b/cmd_exec_commands.c
@@ -59,6 +59,27 @@ int	write_heredoc(t_command_invocation *command, int pipe_heredoc_fd[2])
 	return (0);
 }
 
+static int	cmd_exec_one_command(t_command_invocation *current_cmd,
+	int	pipe_fd[2], int pipe_prev_fd[2], int pipe_heredoc_fd[2])
+{
+	pid_t	pid;
+
+	if (pipe(pipe_fd) || cmd_set_heredoc_pipe_fd(current_cmd, pipe_heredoc_fd))
+		return (put_err_msg_and_ret("error pipe()"));
+	pid = fork();
+	if (pid < 0)
+		return (put_err_msg_and_ret("error fork()"));
+	else if (pid == 0)
+		cmd_exec_command(current_cmd, pipe_prev_fd, pipe_fd,
+			pipe_heredoc_fd);
+	write_heredoc(current_cmd, pipe_heredoc_fd);
+	cmd_close_pipe(pipe_heredoc_fd);
+	current_cmd->pid = pid;
+	if (cmd_connect_pipe(pipe_prev_fd, pipe_fd) != 0)
+		return (put_err_msg_and_ret("error cmd_connect_pipe()"));
+	return (0);
+}
+
 /*
  * fork and execute commands.
  *
@@ -68,7 +89,6 @@ int	write_heredoc(t_command_invocation *command, int pipe_heredoc_fd[2])
  */
 int	cmd_exec_commands(t_command_invocation *command)
 {
-	pid_t					pid;
 	int						pipe_fd[2];
 	int						pipe_prev_fd[2];
 	int						pipe_heredoc_fd[2];
@@ -81,17 +101,9 @@ int	cmd_exec_commands(t_command_invocation *command)
 	cmd_init_pipe_fd(pipe_prev_fd, STDIN_FILENO, -1);
 	while (current_cmd)
 	{
-		if (pipe(pipe_fd) || cmd_set_heredoc_pipe_fd(command, pipe_heredoc_fd))
-			return (put_err_msg_and_ret("error pipe()"));
-		pid = fork();
-		if (pid < 0) return (put_err_msg_and_ret("error fork()"));
-		else if (pid == 0)
-			cmd_exec_command(current_cmd, pipe_prev_fd, pipe_fd, pipe_heredoc_fd);
-		write_heredoc(current_cmd, pipe_heredoc_fd);
-		cmd_close_pipe(pipe_heredoc_fd);
-		current_cmd->pid = pid;
-		if (cmd_connect_pipe(pipe_prev_fd, pipe_fd) != 0)
-			return (put_err_msg_and_ret("error cmd_connect_pipe()"));
+		if (cmd_exec_one_command(current_cmd, pipe_fd, pipe_prev_fd,
+				pipe_heredoc_fd))
+			break ;
 		current_cmd = current_cmd->piped_command;
 	}
 	return (cmd_wait_commands(command));

--- a/cmd_exec_commands.c
+++ b/cmd_exec_commands.c
@@ -51,7 +51,6 @@ int	write_heredoc(t_command_invocation *command, int pipe_prev_fd[2])
 	red = (t_cmd_redirection *)current->content;
 	if (!red->is_heredoc)
 		return (0);
-	close(pipe_prev_fd[0]);
 	printf("----- write(%d) -----\n", pipe_prev_fd[1]);
 	printf("file_path: \n|%s|\n", red->filepath);
 	write(pipe_prev_fd[1], red->filepath, ft_strlen(red->filepath));
@@ -76,7 +75,7 @@ int	cmd_exec_commands(t_command_invocation *command)
 	if (!command->piped_command && command->exec_and_args
 		&& is_builtin_command((char *)command->exec_and_args[0]))
 		return (cmd_exec_builtin(current_cmd));
-	cmd_init_pipe_fd(pipe_prev_fd, STDIN_FILENO, -1);
+	cmd_init_pipe_fd(command, pipe_prev_fd);
 	while (current_cmd)
 	{
 		if (pipe(pipe_fd) == -1)
@@ -86,6 +85,7 @@ int	cmd_exec_commands(t_command_invocation *command)
 			return (put_err_msg_and_ret("error fork()"));
 		else if (pid == 0)
 			cmd_exec_command(current_cmd, pipe_prev_fd, pipe_fd);
+		write_heredoc(current_cmd, pipe_prev_fd);
 		current_cmd->pid = pid;
 		if (cmd_connect_pipe(pipe_prev_fd, pipe_fd) != 0)
 			return (put_err_msg_and_ret("error cmd_connect_pipe()"));

--- a/cmd_exec_commands.c
+++ b/cmd_exec_commands.c
@@ -37,8 +37,8 @@ int	cmd_wait_commands(t_command_invocation *command)
 }
 
 /*
- * input_redirectionsの最後がheredocの場合, pipe_prev_fd(pipe_fd[1]) に書き込みを行う
- * pipe_fd: commandプロセスに対するpipe_fd
+ * Write to pipe_heredoc_fd[1]
+ *   if last element of input_redirections is heredoc.
  */
 int	write_heredoc(t_command_invocation *command, int pipe_heredoc_fd[2])
 {

--- a/cmd_exec_commands.c
+++ b/cmd_exec_commands.c
@@ -33,8 +33,35 @@ int	cmd_wait_commands(t_command_invocation *command)
 	return (status);
 }
 
+#include <stdio.h>
+/*
+ * input_redirectionsの最後がheredocの場合, pipe_prev_fd(pipe_fd[1]) に書き込みを行う
+ * pipe_fd: commandプロセスに対するpipe_fd
+ */
+int	write_heredoc(t_command_invocation *command, int pipe_prev_fd[2])
+{
+	t_list				*current;
+	t_cmd_redirection	*red;
+
+	if (!command->input_redirections)
+		return (0);
+	current = command->input_redirections;
+	while (current->next)
+		current = current->next;
+	red = (t_cmd_redirection *)current->content;
+	if (!red->is_heredoc)
+		return (0);
+	close(pipe_prev_fd[0]);
+	printf("----- write(%d) -----\n", pipe_prev_fd[1]);
+	printf("file_path: \n|%s|\n", red->filepath);
+	write(pipe_prev_fd[1], red->filepath, ft_strlen(red->filepath));
+	return (0);
+}
+
 /*
  * fork and execute commands.
+ *
+ * prev_cmd <1--pipe_prev_fd--0> current_cmd <1--pipe_fd--0> next_cmd
  *
  * return: status of last command
  */

--- a/cmd_exec_commands.c
+++ b/cmd_exec_commands.c
@@ -25,8 +25,11 @@ int	cmd_wait_commands(t_command_invocation *command)
 
 	while (command)
 	{
-		waitpid(command->pid, &status, 0);
-		status = WEXITSTATUS(status);
+		if (command->pid > 0)
+		{
+			waitpid(command->pid, &status, 0);
+			status = WEXITSTATUS(status);
+		}
 		command = command->piped_command;
 	}
 	set_status(status);

--- a/cmd_heredoc_funcs.c
+++ b/cmd_heredoc_funcs.c
@@ -1,0 +1,30 @@
+#include <stdio.h>
+#include <readline/readline.h>
+#include <readline/history.h>
+#include "execution.h"
+#include "minishell.h"
+#include "utils.h"
+
+int	cmd_check_readline_has_finished(void)
+{
+	if (g_shell.heredoc_interruption)
+		rl_done = 1;
+	return 0;
+}
+
+static void	heredoc_sigint_sighandler(int sig)
+{
+	g_shell.heredoc_interruption = 1;
+	set_status(128 + sig);
+}
+
+void	cmd_set_heredoc_sighandlers()
+{
+	g_shell.heredoc_interruption = 0;
+	if (signal(SIGQUIT, SIG_IGN) == SIG_ERR
+		|| signal(SIGINT, heredoc_sigint_sighandler) == SIG_ERR)
+	{
+		printf("signal() failed\n");
+		exit(1);
+	}
+}

--- a/cmd_heredoc_funcs.c
+++ b/cmd_heredoc_funcs.c
@@ -9,7 +9,7 @@ int	cmd_check_readline_has_finished(void)
 {
 	if (g_shell.heredoc_interruption)
 		rl_done = 1;
-	return 0;
+	return (0);
 }
 
 static void	heredoc_sigint_sighandler(int sig)
@@ -18,7 +18,7 @@ static void	heredoc_sigint_sighandler(int sig)
 	set_status(128 + sig);
 }
 
-void	cmd_set_heredoc_sighandlers()
+void	cmd_set_heredoc_sighandlers(void)
 {
 	g_shell.heredoc_interruption = 0;
 	if (signal(SIGQUIT, SIG_IGN) == SIG_ERR
@@ -31,9 +31,10 @@ void	cmd_set_heredoc_sighandlers()
 
 bool	cmd_is_heredoc_expandable(t_parse_node_redirection *redirection_node)
 {
-	bool		is_expandable_heredoc;
+	bool				is_expandable_heredoc;
+	t_parse_node_string	*str_node;
 
-	t_parse_node_string *str_node = redirection_node->string_node->content.string;
+	str_node = redirection_node->string_node->content.string;
 	is_expandable_heredoc = 1;
 	while (str_node)
 	{

--- a/cmd_heredoc_funcs.c
+++ b/cmd_heredoc_funcs.c
@@ -28,3 +28,21 @@ void	cmd_set_heredoc_sighandlers()
 		exit(1);
 	}
 }
+
+bool	cmd_is_heredoc_expandable(t_parse_node_redirection *redirection_node)
+{
+	bool		is_expandable_heredoc;
+
+	t_parse_node_string *str_node = redirection_node->string_node->content.string;
+	is_expandable_heredoc = 1;
+	while (str_node)
+	{
+		if (str_node->type == TOKTYPE_NON_EXPANDABLE)
+			is_expandable_heredoc = 0;
+		if (str_node->next)
+			str_node = str_node->next->content.string;
+		else
+			str_node = NULL;
+	}
+	return (is_expandable_heredoc);
+}

--- a/cmd_pipe.c
+++ b/cmd_pipe.c
@@ -12,8 +12,26 @@ void	cmd_copy_pipe(int pipe_new_fd[2], int pipe_fd[2])
 	pipe_new_fd[1] = pipe_fd[1];
 }
 
-void	cmd_init_pipe_fd(int pipe_fd[2], int pipe0, int pipe1)
+void	cmd_init_pipe_fd(t_command_invocation *command, int pipe_fd[2])
 {
-	pipe_fd[0] = pipe0;
-	pipe_fd[1] = pipe1;
+	t_list				*current;
+	t_cmd_redirection	*red;
+
+	if (!command->input_redirections)
+	{
+		pipe_fd[0] = STDIN_FILENO;
+		pipe_fd[1] = -1;
+		return ;
+	}
+	current = command->input_redirections;
+	while (current->next)
+		current = current->next;
+	red = (t_cmd_redirection *)current->content;
+	if (!red->is_heredoc)
+	{
+		pipe_fd[0] = STDIN_FILENO;
+		pipe_fd[1] = -1;
+	}
+	else
+		pipe(pipe_fd);
 }

--- a/cmd_pipe.c
+++ b/cmd_pipe.c
@@ -12,16 +12,22 @@ void	cmd_copy_pipe(int pipe_new_fd[2], int pipe_fd[2])
 	pipe_new_fd[1] = pipe_fd[1];
 }
 
-void	cmd_init_pipe_fd(t_command_invocation *command, int pipe_fd[2])
+void	cmd_init_pipe_fd(int pipe_fd[2], int pipe0, int pipe1)
 {
-	t_list				*current;
-	t_cmd_redirection	*red;
+	pipe_fd[0] = pipe0;
+	pipe_fd[1] = pipe1;
+}
 
+int	cmd_set_heredoc_pipe_fd(t_command_invocation *command, int pipe_heredoc_fd[2])
+{
+	t_list	*current;
+	t_cmd_redirection	*red;
+	
 	if (!command->input_redirections)
 	{
-		pipe_fd[0] = STDIN_FILENO;
-		pipe_fd[1] = -1;
-		return ;
+		pipe_heredoc_fd[0] = -1;
+		pipe_heredoc_fd[1] = -1;
+		return (0);
 	}
 	current = command->input_redirections;
 	while (current->next)
@@ -29,9 +35,9 @@ void	cmd_init_pipe_fd(t_command_invocation *command, int pipe_fd[2])
 	red = (t_cmd_redirection *)current->content;
 	if (!red->is_heredoc)
 	{
-		pipe_fd[0] = STDIN_FILENO;
-		pipe_fd[1] = -1;
+		pipe_heredoc_fd[0] = -1;
+		pipe_heredoc_fd[1] = -1;
+		return (0);
 	}
-	else
-		pipe(pipe_fd);
+	return (pipe(pipe_heredoc_fd));
 }

--- a/cmd_pipe.c
+++ b/cmd_pipe.c
@@ -18,11 +18,12 @@ void	cmd_init_pipe_fd(int pipe_fd[2], int pipe0, int pipe1)
 	pipe_fd[1] = pipe1;
 }
 
-int	cmd_set_heredoc_pipe_fd(t_command_invocation *command, int pipe_heredoc_fd[2])
+int	cmd_set_heredoc_pipe_fd(t_command_invocation *command,
+	int pipe_heredoc_fd[2])
 {
-	t_list	*current;
+	t_list				*current;
 	t_cmd_redirection	*red;
-	
+
 	if (!command->input_redirections)
 	{
 		pipe_heredoc_fd[0] = -1;

--- a/cmd_redirection.c
+++ b/cmd_redirection.c
@@ -34,13 +34,10 @@ int	put_redirect_fd_err_msg_and_ret(int ret_value, int fd, char *msg)
  */
 char	*expand_redirect_filepath(char *red_target)
 {
-	char	*expanded_str;
 	char	**splitted_expanded_str;
 	char	*filepath;
 
-	expanded_str = expand_env_var(red_target);
-	splitted_expanded_str = split_expanded_str(expanded_str);
-	free(expanded_str);
+	splitted_expanded_str = split_expanded_str(red_target);
 	if (!splitted_expanded_str
 		|| ptrarr_len((void **)splitted_expanded_str) != 1)
 	{

--- a/cmd_redirection.c
+++ b/cmd_redirection.c
@@ -10,7 +10,7 @@
 #include "env.h"
 #include "minishell.h"
 
-int	put_redirect_fd_err_msg_and_ret(int ret_value, int fd, char *msg)
+int	put_redir_errmsg_and_ret(int ret_value, int fd, char *msg)
 {
 	char	*fd_str;
 
@@ -93,16 +93,11 @@ int	cmd_set_input_file(t_command_invocation *command, int pipe_heredoc_fd[2])
 			if (fd == ERROR)
 				return (ERROR);
 			if (dup2(fd, red->fd) == -1)
-				return (put_redirect_fd_err_msg_and_ret(ERROR,
-						red->fd, strerror(errno)));
+				return (put_redir_errmsg_and_ret(-1, red->fd, strerror(errno)));
 		}
-		else
-		{
-			// heredoc(パイプfd)で標準入力を上書き
-			if (pipe_heredoc_fd[0] != -1 && dup2(pipe_heredoc_fd[0], STDIN_FILENO) == -1)
-				return (put_redirect_fd_err_msg_and_ret(ERROR,
-						red->fd, strerror(errno)));
-		}
+		else if (pipe_heredoc_fd[0] != -1
+			&& dup2(pipe_heredoc_fd[0], STDIN_FILENO) == -1)
+			return (put_redir_errmsg_and_ret(-1, red->fd, strerror(errno)));
 		current = current->next;
 	}
 	close(pipe_heredoc_fd[0]);
@@ -133,7 +128,7 @@ int	cmd_set_output_file(t_command_invocation *command)
 		if (fd == ERROR)
 			return (ERROR);
 		if (dup2(fd, red->fd) == -1)
-			return (put_redirect_fd_err_msg_and_ret(ERROR,
+			return (put_redir_errmsg_and_ret(ERROR,
 					red->fd, strerror(errno)));
 		current = current->next;
 	}

--- a/cmd_redirection.c
+++ b/cmd_redirection.c
@@ -34,10 +34,13 @@ int	put_redirect_fd_err_msg_and_ret(int ret_value, int fd, char *msg)
  */
 char	*expand_redirect_filepath(char *red_target)
 {
+	char	*expanded_str;
 	char	**splitted_expanded_str;
 	char	*filepath;
 
-	splitted_expanded_str = split_expanded_str(red_target);
+	expanded_str = expand_env_var(red_target);
+	splitted_expanded_str = split_expanded_str(expanded_str);
+	free(expanded_str);
 	if (!splitted_expanded_str
 		|| ptrarr_len((void **)splitted_expanded_str) != 1)
 	{

--- a/convert_ast2cmdinvo.c
+++ b/convert_ast2cmdinvo.c
@@ -133,8 +133,12 @@ t_command_invocation	*cmd_ast_pipcmds2cmdinvo(t_parse_node_pipcmds *pipcmds)
 	while (pipcmds)
 	{
 		command = cmd_ast_cmd2cmdinvo(pipcmds->command_node->content.command);
-		if (command)
-			cmd_cmdinvo_add_pipcmd(&commands, command);
+		if (!command)
+		{
+			cmd_free_cmdinvo(commands);
+			return (NULL);
+		}
+		cmd_cmdinvo_add_pipcmd(&commands, command);
 		if (pipcmds->next)
 			pipcmds = pipcmds->next->content.piped_commands;
 		else

--- a/convert_ast2cmdinvo.c
+++ b/convert_ast2cmdinvo.c
@@ -51,13 +51,13 @@ int	cmd_process_redirection_node(t_parse_node_redirection *redirection_node,
 	if (!text)
 		return (ERROR);
 	if (redirection_type == TOKTYPE_INPUT_REDIRECTION)
-		cmd_add_inredirect(command, text, fd);
+		return (cmd_add_inredirect(command, text, fd));
 	else if (redirection_type == TOKTYPE_OUTPUT_REDIRECTION)
-		cmd_add_outredirect(command, text, fd, false);
+		return (cmd_add_outredirect(command, text, fd, false));
 	else if (redirection_type == TOKTYPE_OUTPUT_APPENDING)
-		cmd_add_outredirect(command, text, fd, true);
+		return (cmd_add_outredirect(command, text, fd, true));
 	else if (redirection_type == TOKTYPE_HEREDOCUMENT)
-		cmd_add_heredoc(command, text, fd);
+		return (cmd_add_heredoc(command, text, fd));
 	return (0);
 }
 
@@ -73,11 +73,11 @@ int	cmd_process_arguments_node(t_parse_node_arguments *args_node,
 	t_command_invocation *command)
 {
 	if (args_node->string_node)
-		cmd_process_string_node(
-			args_node->string_node->content.string, command);
+		return (cmd_process_string_node(
+			args_node->string_node->content.string, command));
 	else if (args_node->redirection_node)
-		cmd_process_redirection_node(
-			args_node->redirection_node->content.redirection, command);
+		return (cmd_process_redirection_node(
+			args_node->redirection_node->content.redirection, command));
 	else
 		return (1);
 	return (0);
@@ -101,7 +101,11 @@ t_command_invocation	*cmd_ast_cmd2cmdinvo(t_parse_node_command *cmd_node)
 	args_node = cmd_node->arguments_node->content.arguments;
 	while (args_node)
 	{
-		cmd_process_arguments_node(args_node, cmdinvo);
+		if (cmd_process_arguments_node(args_node, cmdinvo))
+		{
+			cmd_free_cmdinvo(cmdinvo);
+			return (NULL);
+		}
 		if (args_node->rest_node)
 			args_node = args_node->rest_node->content.arguments;
 		else
@@ -126,7 +130,8 @@ t_command_invocation	*cmd_ast_pipcmds2cmdinvo(t_parse_node_pipcmds *pipcmds)
 	while (pipcmds)
 	{
 		command = cmd_ast_cmd2cmdinvo(pipcmds->command_node->content.command);
-		cmd_cmdinvo_add_pipcmd(&commands, command);
+		if (command)
+			cmd_cmdinvo_add_pipcmd(&commands, command);
 		if (pipcmds->next)
 			pipcmds = pipcmds->next->content.piped_commands;
 		else

--- a/convert_ast2cmdinvo.c
+++ b/convert_ast2cmdinvo.c
@@ -48,7 +48,7 @@ int	cmd_process_redirection_node(t_parse_node_redirection *redirection_node,
 	int			status;
 
 	redirection_type = redirection_node->type;
-	text = expand_strnode4red(redirection_node->string_node->content.string);
+	text = string_node2string(redirection_node->string_node->content.string);
 	is_expandable_heredoc = redirection_node->string_node->content.string->type != TOKTYPE_NON_EXPANDABLE;
 	fd = redirection_node->fd;
 	status = 0;

--- a/convert_ast2cmdinvo.c
+++ b/convert_ast2cmdinvo.c
@@ -48,7 +48,7 @@ int	cmd_process_redirection_node(t_parse_node_redirection *redirection_node,
 	int			status;
 
 	redirection_type = redirection_node->type;
-	text = string_node2string(redirection_node->string_node->content.string);
+	text = expand_strnode4red(redirection_node->string_node->content.string);
 	is_expandable_heredoc = redirection_node->string_node->content.string->type != TOKTYPE_NON_EXPANDABLE;
 	fd = redirection_node->fd;
 	status = 0;

--- a/convert_ast2cmdinvo.c
+++ b/convert_ast2cmdinvo.c
@@ -56,6 +56,8 @@ int	cmd_process_redirection_node(t_parse_node_redirection *redirection_node,
 		cmd_add_outredirect(command, text, fd, false);
 	else if (redirection_type == TOKTYPE_OUTPUT_APPENDING)
 		cmd_add_outredirect(command, text, fd, true);
+	else if (redirection_type == TOKTYPE_HEREDOCUMENT)
+		cmd_add_heredoc(command, text, fd);
 	return (0);
 }
 

--- a/convert_ast2cmdinvo.c
+++ b/convert_ast2cmdinvo.c
@@ -43,11 +43,13 @@ int	cmd_process_redirection_node(t_parse_node_redirection *redirection_node,
 {
 	int			redirection_type;
 	const char	*text;
+	bool		is_expandable_heredoc;
 	int			fd;
 	int			status;
 
 	redirection_type = redirection_node->type;
 	text = string_node2string(redirection_node->string_node->content.string);
+	is_expandable_heredoc = redirection_node->string_node->content.string->type != TOKTYPE_NON_EXPANDABLE;
 	fd = redirection_node->fd;
 	status = 0;
 	if (!text)
@@ -59,7 +61,7 @@ int	cmd_process_redirection_node(t_parse_node_redirection *redirection_node,
 	else if (redirection_type == TOKTYPE_OUTPUT_APPENDING)
 		status = cmd_add_outredirect(command, text, fd, true);
 	else if (redirection_type == TOKTYPE_HEREDOCUMENT)
-		status = cmd_add_heredoc(command, text, fd);
+		status = cmd_add_heredoc(command, text, fd, is_expandable_heredoc);
 	free((void *)text);
 	return (status);
 }

--- a/convert_ast2cmdinvo.c
+++ b/convert_ast2cmdinvo.c
@@ -38,6 +38,7 @@ int	cmd_process_string_node(t_parse_node_string *string_node,
  *     | ">" string
  *     | ">>" string
  */
+#include <stdio.h>
 int	cmd_process_redirection_node(t_parse_node_redirection *redirection_node,
 	t_command_invocation *command)
 {
@@ -48,8 +49,23 @@ int	cmd_process_redirection_node(t_parse_node_redirection *redirection_node,
 	int			status;
 
 	redirection_type = redirection_node->type;
-	text = string_node2string(redirection_node->string_node->content.string);
-	is_expandable_heredoc = redirection_node->string_node->content.string->type != TOKTYPE_NON_EXPANDABLE;
+	text = string_node2string(redirection_node->string_node->content.string, redirection_type != TOKTYPE_HEREDOCUMENT);
+
+	// heredoc が expandable かどうか取得する
+	t_parse_node_string *str_node = redirection_node->string_node->content.string;
+	is_expandable_heredoc = 1;
+	while (str_node)
+	{
+		if (str_node->type == TOKTYPE_NON_EXPANDABLE)
+			is_expandable_heredoc = 0;
+		if (str_node->next)
+			str_node = str_node->next->content.string;
+		else
+			str_node = NULL;
+	}
+
+	printf("text: |%s|, is_expandable: %d\n", text, is_expandable_heredoc);
+
 	fd = redirection_node->fd;
 	status = 0;
 	if (!text)

--- a/convert_ast2cmdinvo.c
+++ b/convert_ast2cmdinvo.c
@@ -101,8 +101,7 @@ t_command_invocation	*cmd_ast_cmd2cmdinvo(t_parse_node_command *cmd_node)
 	t_parse_node_arguments	*args_node;
 
 	cmdinvo = cmd_init_cmdinvo(NULL);
-	if (!cmdinvo)
-		put_minish_err_msg_and_exit(1, "ast2cmdinvo", "malloc() failed");
+	check_malloc_has_succeeded("ast2cmdinvo", cmdinvo);
 	args_node = cmd_node->arguments_node->content.arguments;
 	while (args_node)
 	{

--- a/convert_ast2cmdinvo.c
+++ b/convert_ast2cmdinvo.c
@@ -44,21 +44,24 @@ int	cmd_process_redirection_node(t_parse_node_redirection *redirection_node,
 	int			redirection_type;
 	const char	*text;
 	int			fd;
+	int			status;
 
 	redirection_type = redirection_node->type;
 	text = string_node2string(redirection_node->string_node->content.string);
 	fd = redirection_node->fd;
+	status = 0;
 	if (!text)
 		return (ERROR);
 	if (redirection_type == TOKTYPE_INPUT_REDIRECTION)
-		return (cmd_add_inredirect(command, text, fd));
+		status = cmd_add_inredirect(command, text, fd);
 	else if (redirection_type == TOKTYPE_OUTPUT_REDIRECTION)
-		return (cmd_add_outredirect(command, text, fd, false));
+		status = cmd_add_outredirect(command, text, fd, false);
 	else if (redirection_type == TOKTYPE_OUTPUT_APPENDING)
-		return (cmd_add_outredirect(command, text, fd, true));
+		status = cmd_add_outredirect(command, text, fd, true);
 	else if (redirection_type == TOKTYPE_HEREDOCUMENT)
-		return (cmd_add_heredoc(command, text, fd));
-	return (0);
+		status = cmd_add_heredoc(command, text, fd);
+	free((void *)text);
+	return (status);
 }
 
 /* parse argument_node and set values of command

--- a/convert_ast2cmdinvo.c
+++ b/convert_ast2cmdinvo.c
@@ -100,7 +100,7 @@ t_command_invocation	*cmd_ast_cmd2cmdinvo(t_parse_node_command *cmd_node)
 
 	cmdinvo = cmd_init_cmdinvo(NULL);
 	if (!cmdinvo)
-		return (NULL);
+		put_minish_err_msg_and_exit(1, "ast2cmdinvo", "malloc() failed");
 	args_node = cmd_node->arguments_node->content.arguments;
 	while (args_node)
 	{

--- a/env.h
+++ b/env.h
@@ -22,6 +22,7 @@ t_var	*get_env(const char *env_key);
 char	*get_env_val(const char *env_key);
 char	**split_first_c(const char *str, char c);
 char	**get_colon_units(const char *str, const char *default_str);
+char	*generate_kvstr(const char *key, const char *value);
 char	*get_val_from_kvstr(const char *kvstr, char delimiter);
 int		ft_setenv(const char *key, const char *value, bool is_shell_var);
 int		ft_unsetenv(const char *key);
@@ -36,7 +37,6 @@ char	*exp_result_join_normal_str(char *result,
 char	*exp_expand_env_and_join(char *result,
 			char *str, int env_len);
 char	*expand_env_var(char *str);
-char	*generate_kvstr(const char *key, const char *value);
 
 // Utilities for command exit code.
 int		get_status(void);

--- a/env.h
+++ b/env.h
@@ -23,10 +23,20 @@ char	*get_env_val(const char *env_key);
 char	**split_first_c(const char *str, char c);
 char	**get_colon_units(const char *str, const char *default_str);
 char	*get_val_from_kvstr(const char *kvstr, char delimiter);
-char	*expand_env_var(char *str);
-char	*generate_kvstr(const char *key, const char *value);
 int		ft_setenv(const char *key, const char *value, bool is_shell_var);
 int		ft_unsetenv(const char *key);
+
+// Expander (exp)
+bool	exp_join_str_or_env(char **result,
+			char **str, int *len, bool *is_in_env);
+bool	exp_will_toggle_env(bool is_in_env,
+			bool is_in_noexpand, char *str, int len);
+char	*exp_result_join_normal_str(char *result,
+			char *str, int len);
+char	*exp_expand_env_and_join(char *result,
+			char *str, int env_len);
+char	*expand_env_var(char *str);
+char	*generate_kvstr(const char *key, const char *value);
 
 // Utilities for command exit code.
 int		get_status(void);

--- a/env_expander.c
+++ b/env_expander.c
@@ -8,7 +8,7 @@
  * Old result will be freed
  *   so caller doesn't need to free result after calling this function.
  */
-static char	*expand_env_and_join(char *result,
+char	*expand_env_and_join(char *result,
 	char *str, int env_len)
 {
 	char	*keyname;
@@ -40,7 +40,7 @@ static char	*expand_env_and_join(char *result,
  * Old result will be freed
  *   so caller doesn't need to free result after calling this function.
  */
-static char	*result_join_normal_str(char *result,
+char	*exp_result_join_normal_str(char *result,
 	char *str, int len)
 {
 	char	*tmp;
@@ -70,7 +70,7 @@ static char	*result_join_normal_str(char *result,
  *       srt[len] is invalid character as variable key.
  *   - str[len] has reached to the end of string.
  */
-static bool	will_toggle_env(bool is_in_env,
+bool	exp_will_toggle_env(bool is_in_env,
 	bool is_in_noexpand, char *str, int len)
 {
 	bool	will_start_env;
@@ -96,13 +96,13 @@ static bool	will_toggle_env(bool is_in_env,
  *
  * return: whether continue string processing.
  */
-static bool	join_str_or_env(char **result,
+bool	exp_join_str_or_env(char **result,
 	char **str, int *len, bool *is_in_env)
 {
 	if (*is_in_env)
 		*result = expand_env_and_join(*result, *str, *len);
 	else
-		*result = result_join_normal_str(*result, *str, *len);
+		*result = exp_result_join_normal_str(*result, *str, *len);
 	if (!(*str)[*len] || !result)
 		return (false);
 	*str += *len + !*is_in_env;
@@ -137,53 +137,8 @@ char	*expand_env_var(char *str)
 	{
 		if (str[len] == '\'' && !(len > 0 && str[len - 1] == '\\'))
 			is_in_noexpand = !is_in_noexpand;
-		if (will_toggle_env(is_in_env, is_in_noexpand, str, len))
-			is_continue = join_str_or_env(&result, &str, &len, &is_in_env);
-		else
-			len++;
-	}
-	return (result);
-}
-
-/* Expand variables in document of heredoc.
- *
- * ex:
- *   in($ABC="hoge"):       |\$USER \\$USER $USER '$USER' "$USER" \"\'\$|
- *   out:                   |$USER \jun jun 'jun' "jun" \"\'$|
- */
-char	*expand_heredoc_document(char *str)
-{
-	char	*result;
-	int		len;  // 現在見ている範囲の長さ. 先頭は*strを直接動かす
-	bool	is_in_env;  // 現在環境変数にいるか
-	char	*tmpstr;
-	bool	is_continue;
-
-	result = ft_strdup("");
-	is_continue = true;
-	len = 0;
-	is_in_env = false;
-	while (is_continue)
-	{
-		// エスケープの処理
-		if (str[len] == '\\')
-		{
-			if (is_in_env)
-				is_continue = join_str_or_env(&result, &str, &len, &is_in_env);
-			// ここまでの文字列を繋げる
-			// バックスラッシュの次の文字が特殊文字('$' | '\')じゃなければバックスラッシュも入れる
-			tmpstr = ft_substr(str, 0, len + !(str[len + 1] == '$' || str[len + 1] == '\\'));
-			result = strjoin_and_free_both(result, tmpstr);
-			str += len + 1;
-			// バックスラッシュの次の文字を繋げる
-			tmpstr = ft_substr(str, 0, 1);
-			result = strjoin_and_free_both(result, tmpstr);
-			str += 1;
-			len = 0;
-		}
-		// ドルマーク($) 環境変数開始の処理
-		else if (will_toggle_env(is_in_env, false, str, len))
-			is_continue = join_str_or_env(&result, &str, &len, &is_in_env);
+		if (exp_will_toggle_env(is_in_env, is_in_noexpand, str, len))
+			is_continue = exp_join_str_or_env(&result, &str, &len, &is_in_env);
 		else
 			len++;
 	}

--- a/env_expander.c
+++ b/env_expander.c
@@ -8,7 +8,7 @@
  * Old result will be freed
  *   so caller doesn't need to free result after calling this function.
  */
-char	*expand_env_and_join(char *result,
+char	*exp_expand_env_and_join(char *result,
 	char *str, int env_len)
 {
 	char	*keyname;
@@ -100,7 +100,7 @@ bool	exp_join_str_or_env(char **result,
 	char **str, int *len, bool *is_in_env)
 {
 	if (*is_in_env)
-		*result = expand_env_and_join(*result, *str, *len);
+		*result = exp_expand_env_and_join(*result, *str, *len);
 	else
 		*result = exp_result_join_normal_str(*result, *str, *len);
 	if (!(*str)[*len] || !result)

--- a/execution.h
+++ b/execution.h
@@ -59,6 +59,8 @@ int						cmd_add_inredirect(t_command_invocation *command,
 							const char *filepath, int fd);
 int						cmd_add_heredoc(t_command_invocation *command,
 							const char *limit_str, int fd);
+int						cmd_check_readline_has_finished(void);
+void					cmd_set_heredoc_sighandlers(void);
 int						cmd_add_outredirect(t_command_invocation *command,
 							const char *filepath, int fd, bool is_append);
 void					cmd_del_redirection(void *redirection);

--- a/execution.h
+++ b/execution.h
@@ -47,8 +47,9 @@ void					cmd_exec_command(t_command_invocation *command,
 int						cmd_exec_builtin(t_command_invocation *command);
 void					cmd_close_pipe(int pipe_fd[2]);
 void					cmd_copy_pipe(int pipe_new_fd[2], int pipe_fd[2]);
-// void					cmd_init_pipe_fd(int pipe_fd[2], int pipe0, int pipe1);
-void					cmd_init_pipe_fd(t_command_invocation *command, int pipe_fd[2]);
+void					cmd_init_pipe_fd(int pipe_fd[2], int pipe0, int pipe1);
+int						cmd_set_heredoc_pipe_fd(t_command_invocation *command,
+							int pipe_heredoc_fd[2]);
 t_list					*cmd_lstadd_back_pid(t_list **lst, int pid);
 int						cmd_wait_pid_lst(t_list *lst);
 t_command_invocation	*cmd_init_cmdinvo(const char **exec_and_args);

--- a/execution.h
+++ b/execution.h
@@ -42,7 +42,7 @@ int						cmd_exec_commands(t_command_invocation *command);
 char					*expand_redirect_filepath(char *red_target);
 int						open_file_for_redirect(t_cmd_redirection *red,
 							int open_flags, mode_t open_mode);
-int						put_redirect_fd_err_msg_and_ret(int ret_value,
+int						put_redir_errmsg_and_ret(int ret_value,
 							int fd, char *msg);
 int						cmd_set_input_file(t_command_invocation *command,
 							int heredoc_pipe[2]);

--- a/execution.h
+++ b/execution.h
@@ -8,6 +8,7 @@ typedef struct s_cmd_redirection
 {
 	const char	*filepath;
 	bool		is_append;
+	bool		is_heredoc;
 	int			fd;
 }	t_cmd_redirection;
 
@@ -54,6 +55,8 @@ t_command_invocation	*cmd_cmdinvo_add_pipcmd(t_command_invocation **cmds,
 							t_command_invocation *newcmd);
 int						cmd_add_inredirect(t_command_invocation *command,
 							const char *filepath, int fd);
+int						cmd_add_heredoc(t_command_invocation *command,
+							const char *limit_str, int fd);
 int						cmd_add_outredirect(t_command_invocation *command,
 							const char *filepath, int fd, bool is_append);
 void					cmd_del_redirection(void *redirection);

--- a/execution.h
+++ b/execution.h
@@ -5,9 +5,6 @@
 # include "libft/libft.h"
 # include "parse.h"
 
-# define HEREDOC_EXPANDABLE   0b01
-# define HEREDOC_NOEXPANDABLE 0b10
-
 typedef struct s_cmd_redirection
 {
 	const char	*filepath;

--- a/execution.h
+++ b/execution.h
@@ -44,17 +44,20 @@ int						open_file_for_redirect(t_cmd_redirection *red,
 							int open_flags, mode_t open_mode);
 int						put_redirect_fd_err_msg_and_ret(int ret_value,
 							int fd, char *msg);
-int						cmd_set_input_file(t_command_invocation *command, int heredoc_pipe[2]);
+int						cmd_set_input_file(t_command_invocation *command,
+							int heredoc_pipe[2]);
 int						cmd_set_output_file(t_command_invocation *command);
 void					cmd_exec_command(t_command_invocation *command,
-							int pipe_prev_fd[2], int pipe_fd[2], int heredoc_pipe[2]);
+							int pipe_prev_fd[2], int pipe_fd[2],
+							int heredoc_pipe[2]);
 int						cmd_exec_builtin(t_command_invocation *command);
 void					cmd_close_pipe(int pipe_fd[2]);
 void					cmd_copy_pipe(int pipe_new_fd[2], int pipe_fd[2]);
 void					cmd_init_pipe_fd(int pipe_fd[2], int pipe0, int pipe1);
 int						cmd_set_heredoc_pipe_fd(t_command_invocation *command,
 							int pipe_heredoc_fd[2]);
-bool					cmd_is_heredoc_expandable(t_parse_node_redirection *redirection_node);
+bool					cmd_is_heredoc_expandable(
+							t_parse_node_redirection *redirection_node);
 char					*expand_heredoc_document(char *str);
 t_list					*cmd_lstadd_back_pid(t_list **lst, int pid);
 int						cmd_wait_pid_lst(t_list *lst);

--- a/execution.h
+++ b/execution.h
@@ -40,10 +40,10 @@ int						open_file_for_redirect(t_cmd_redirection *red,
 							int open_flags, mode_t open_mode);
 int						put_redirect_fd_err_msg_and_ret(int ret_value,
 							int fd, char *msg);
-int						cmd_set_input_file(t_command_invocation *command);
+int						cmd_set_input_file(t_command_invocation *command, int heredoc_pipe[2]);
 int						cmd_set_output_file(t_command_invocation *command);
 void					cmd_exec_command(t_command_invocation *command,
-							int pipe_prev_fd[2], int pipe_fd[2]);
+							int pipe_prev_fd[2], int pipe_fd[2], int heredoc_pipe[2]);
 int						cmd_exec_builtin(t_command_invocation *command);
 void					cmd_close_pipe(int pipe_fd[2]);
 void					cmd_copy_pipe(int pipe_new_fd[2], int pipe_fd[2]);

--- a/execution.h
+++ b/execution.h
@@ -3,6 +3,7 @@
 
 # include <unistd.h>
 # include "libft/libft.h"
+# include "parse.h"
 
 # define HEREDOC_EXPANDABLE   0b01
 # define HEREDOC_NOEXPANDABLE 0b10
@@ -53,6 +54,7 @@ void					cmd_copy_pipe(int pipe_new_fd[2], int pipe_fd[2]);
 void					cmd_init_pipe_fd(int pipe_fd[2], int pipe0, int pipe1);
 int						cmd_set_heredoc_pipe_fd(t_command_invocation *command,
 							int pipe_heredoc_fd[2]);
+bool					cmd_is_heredoc_expandable(t_parse_node_redirection *redirection_node);
 char					*expand_heredoc_document(char *str);
 t_list					*cmd_lstadd_back_pid(t_list **lst, int pid);
 int						cmd_wait_pid_lst(t_list *lst);

--- a/execution.h
+++ b/execution.h
@@ -68,7 +68,6 @@ int						cmd_add_outredirect(t_command_invocation *command,
 							const char *filepath, int fd, bool is_append);
 void					cmd_del_redirection(void *redirection);
 void					cmd_free_cmdinvo(t_command_invocation *cmds);
-char					*expand_env_var(char *str);
 void					fd_list_close(t_fd_list **lst);
 t_fd_list				*fd_list_add_fd(t_fd_list **lst, int fd);
 

--- a/execution.h
+++ b/execution.h
@@ -4,6 +4,9 @@
 # include <unistd.h>
 # include "libft/libft.h"
 
+# define HEREDOC_EXPANDABLE   0b01
+# define HEREDOC_NOEXPANDABLE 0b10
+
 typedef struct s_cmd_redirection
 {
 	const char	*filepath;
@@ -58,7 +61,7 @@ t_command_invocation	*cmd_cmdinvo_add_pipcmd(t_command_invocation **cmds,
 int						cmd_add_inredirect(t_command_invocation *command,
 							const char *filepath, int fd);
 int						cmd_add_heredoc(t_command_invocation *command,
-							const char *limit_str, int fd);
+							const char *limit_str, int fd, bool is_expandable);
 int						cmd_check_readline_has_finished(void);
 void					cmd_set_heredoc_sighandlers(void);
 int						cmd_add_outredirect(t_command_invocation *command,

--- a/execution.h
+++ b/execution.h
@@ -53,6 +53,7 @@ void					cmd_copy_pipe(int pipe_new_fd[2], int pipe_fd[2]);
 void					cmd_init_pipe_fd(int pipe_fd[2], int pipe0, int pipe1);
 int						cmd_set_heredoc_pipe_fd(t_command_invocation *command,
 							int pipe_heredoc_fd[2]);
+char					*expand_heredoc_document(char *str);
 t_list					*cmd_lstadd_back_pid(t_list **lst, int pid);
 int						cmd_wait_pid_lst(t_list *lst);
 t_command_invocation	*cmd_init_cmdinvo(const char **exec_and_args);

--- a/execution.h
+++ b/execution.h
@@ -47,7 +47,8 @@ void					cmd_exec_command(t_command_invocation *command,
 int						cmd_exec_builtin(t_command_invocation *command);
 void					cmd_close_pipe(int pipe_fd[2]);
 void					cmd_copy_pipe(int pipe_new_fd[2], int pipe_fd[2]);
-void					cmd_init_pipe_fd(int pipe_fd[2], int pipe0, int pipe1);
+// void					cmd_init_pipe_fd(int pipe_fd[2], int pipe0, int pipe1);
+void					cmd_init_pipe_fd(t_command_invocation *command, int pipe_fd[2]);
 t_list					*cmd_lstadd_back_pid(t_list **lst, int pid);
 int						cmd_wait_pid_lst(t_list *lst);
 t_command_invocation	*cmd_init_cmdinvo(const char **exec_and_args);

--- a/expand_env_var.c
+++ b/expand_env_var.c
@@ -119,7 +119,6 @@ static bool	join_str_or_env(char **result,
  *   in($ABC="hoge"):       |'$''$'"ABC"'\'"$ABC""$ABC"|
  *   out:                   |'$''$'"ABC"'\'"hoge""hoge"|
  */
-// TODO: シングルクオートなどの処理を消す
 char	*expand_env_var(char *str)
 {
 	int		len;

--- a/expand_env_var.c
+++ b/expand_env_var.c
@@ -119,6 +119,7 @@ static bool	join_str_or_env(char **result,
  *   in($ABC="hoge"):       |'$''$'"ABC"'\'"$ABC""$ABC"|
  *   out:                   |'$''$'"ABC"'\'"hoge""hoge"|
  */
+// TODO: シングルクオートなどの処理を消す
 char	*expand_env_var(char *str)
 {
 	int		len;

--- a/expand_env_var.c
+++ b/expand_env_var.c
@@ -1,5 +1,5 @@
+#include "libft/libft.h"
 #include "env.h"
-#include "minishell.h"
 
 /*
  * Get the variables with key substr(str, 0, env_len)

--- a/expand_env_var.c
+++ b/expand_env_var.c
@@ -1,5 +1,6 @@
 #include "libft/libft.h"
 #include "env.h"
+#include "utils.h"
 
 /*
  * Get the variables with key substr(str, 0, env_len)
@@ -137,6 +138,51 @@ char	*expand_env_var(char *str)
 		if (str[len] == '\'' && !(len > 0 && str[len - 1] == '\\'))
 			is_in_noexpand = !is_in_noexpand;
 		if (will_toggle_env(is_in_env, is_in_noexpand, str, len))
+			is_continue = join_str_or_env(&result, &str, &len, &is_in_env);
+		else
+			len++;
+	}
+	return (result);
+}
+
+/* Expand variables in document of heredoc.
+ *
+ * ex:
+ *   in($ABC="hoge"):       |\$USER \\$USER $USER '$USER' "$USER" \"\'\$|
+ *   out:                   |$USER \jun jun 'jun' "jun" \"\'$|
+ */
+char	*expand_heredoc_document(char *str)
+{
+	char	*result;
+	int		len;  // 現在見ている範囲の長さ. 先頭は*strを直接動かす
+	bool	is_in_env;  // 現在環境変数にいるか
+	char	*tmpstr;
+	bool	is_continue;
+
+	result = ft_strdup("");
+	is_continue = true;
+	len = 0;
+	is_in_env = false;
+	while (is_continue)
+	{
+		// エスケープの処理
+		if (str[len] == '\\')
+		{
+			if (is_in_env)
+				is_continue = join_str_or_env(&result, &str, &len, &is_in_env);
+			// ここまでの文字列を繋げる
+			// バックスラッシュの次の文字が特殊文字('$' | '\')じゃなければバックスラッシュも入れる
+			tmpstr = ft_substr(str, 0, len + !(str[len + 1] == '$' || str[len + 1] == '\\'));
+			result = strjoin_and_free_both(result, tmpstr);
+			str += len + 1;
+			// バックスラッシュの次の文字を繋げる
+			tmpstr = ft_substr(str, 0, 1);
+			result = strjoin_and_free_both(result, tmpstr);
+			str += 1;
+			len = 0;
+		}
+		// ドルマーク($) 環境変数開始の処理
+		else if (will_toggle_env(is_in_env, false, str, len))
 			is_continue = join_str_or_env(&result, &str, &len, &is_in_env);
 		else
 			len++;

--- a/expand_string_node.c
+++ b/expand_string_node.c
@@ -1,4 +1,5 @@
 #include "minishell.h"
+#include "env.h"
 #include "utils.h"
 
 static bool	cmd_str_node_add_back(t_cmd_str_node ***str_node_arr,

--- a/expand_string_node.c
+++ b/expand_string_node.c
@@ -1,5 +1,4 @@
 #include "minishell.h"
-#include "env.h"
 #include "utils.h"
 
 static bool	cmd_str_node_add_back(t_cmd_str_node ***str_node_arr,

--- a/heredoc_expander.c
+++ b/heredoc_expander.c
@@ -1,0 +1,49 @@
+#include "libft/libft.h"
+#include "env.h"
+#include "execution.h"
+#include "utils.h"
+
+/* Expand variables in document of heredoc.
+ *
+ * ex:
+ *   in($ABC="hoge"):       |\$USER \\$USER $USER '$USER' "$USER" \"\'\$|
+ *   out:                   |$USER \jun jun 'jun' "jun" \"\'$|
+ */
+char	*expand_heredoc_document(char *str)
+{
+	char	*result;
+	int		len;  // 現在見ている範囲の長さ. 先頭は*strを直接動かす
+	bool	is_in_env;  // 現在環境変数にいるか
+	char	*tmpstr;
+	bool	is_continue;
+
+	result = ft_strdup("");
+	is_continue = true;
+	len = 0;
+	is_in_env = false;
+	while (is_continue)
+	{
+		// エスケープの処理
+		if (str[len] == '\\')
+		{
+			if (is_in_env)
+				is_continue = exp_join_str_or_env(&result, &str, &len, &is_in_env);
+			// ここまでの文字列を繋げる
+			// バックスラッシュの次の文字が特殊文字('$' | '\')じゃなければバックスラッシュも入れる
+			tmpstr = ft_substr(str, 0, len + !(str[len + 1] == '$' || str[len + 1] == '\\'));
+			result = strjoin_and_free_both(result, tmpstr);
+			str += len + 1;
+			// バックスラッシュの次の文字を繋げる
+			tmpstr = ft_substr(str, 0, 1);
+			result = strjoin_and_free_both(result, tmpstr);
+			str += 1;
+			len = 0;
+		}
+		// ドルマーク($) 環境変数開始の処理
+		else if (exp_will_toggle_env(is_in_env, false, str, len))
+			is_continue = exp_join_str_or_env(&result, &str, &len, &is_in_env);
+		else
+			len++;
+	}
+	return (result);
+}

--- a/heredoc_expander.c
+++ b/heredoc_expander.c
@@ -1,7 +1,28 @@
 #include "libft/libft.h"
+#include "minishell.h"
 #include "env.h"
 #include "execution.h"
 #include "utils.h"
+
+static void process_escape(char **result, char **str, int *len)
+{
+	char	*tmpstr;
+
+	// ここまでの文字列を繋げる
+	// バックスラッシュの次の文字が特殊文字('$' | '\')じゃなければバックスラッシュも入れる
+	tmpstr = ft_substr(*str, 0, *len + !((*str)[*len + 1] == '$' || (*str)[*len + 1] == '\\'));
+	check_malloc_has_succeeded("heredoc expander", tmpstr);
+	*result = strjoin_and_free_both(*result, tmpstr);
+	check_malloc_has_succeeded("heredoc expander", *result);
+	*str += *len + 1;
+	// バックスラッシュの次の文字を繋げる
+	tmpstr = ft_substr(*str, 0, 1);
+	check_malloc_has_succeeded("heredoc expander", tmpstr);
+	*result = strjoin_and_free_both(*result, tmpstr);
+	check_malloc_has_succeeded("heredoc expander", *result);
+	*str += 1;
+	*len = 0;
+}
 
 /* Expand variables in document of heredoc.
  *
@@ -14,10 +35,10 @@ char	*expand_heredoc_document(char *str)
 	char	*result;
 	int		len;  // 現在見ている範囲の長さ. 先頭は*strを直接動かす
 	bool	is_in_env;  // 現在環境変数にいるか
-	char	*tmpstr;
 	bool	is_continue;
 
 	result = ft_strdup("");
+	check_malloc_has_succeeded("heredoc expander", result);
 	is_continue = true;
 	len = 0;
 	is_in_env = false;
@@ -28,16 +49,7 @@ char	*expand_heredoc_document(char *str)
 		{
 			if (is_in_env)
 				is_continue = exp_join_str_or_env(&result, &str, &len, &is_in_env);
-			// ここまでの文字列を繋げる
-			// バックスラッシュの次の文字が特殊文字('$' | '\')じゃなければバックスラッシュも入れる
-			tmpstr = ft_substr(str, 0, len + !(str[len + 1] == '$' || str[len + 1] == '\\'));
-			result = strjoin_and_free_both(result, tmpstr);
-			str += len + 1;
-			// バックスラッシュの次の文字を繋げる
-			tmpstr = ft_substr(str, 0, 1);
-			result = strjoin_and_free_both(result, tmpstr);
-			str += 1;
-			len = 0;
+			process_escape(&result, &str, &len);
 		}
 		// ドルマーク($) 環境変数開始の処理
 		else if (exp_will_toggle_env(is_in_env, false, str, len))

--- a/heredoc_expander.c
+++ b/heredoc_expander.c
@@ -4,18 +4,16 @@
 #include "execution.h"
 #include "utils.h"
 
-static void process_escape(char **result, char **str, int *len)
+static void	process_escape(char **result, char **str, int *len)
 {
 	char	*tmpstr;
 
-	// ここまでの文字列を繋げる
-	// バックスラッシュの次の文字が特殊文字('$' | '\')じゃなければバックスラッシュも入れる
-	tmpstr = ft_substr(*str, 0, *len + !((*str)[*len + 1] == '$' || (*str)[*len + 1] == '\\'));
+	tmpstr = ft_substr(*str, 0,
+			*len + !((*str)[*len + 1] == '$' || (*str)[*len + 1] == '\\'));
 	check_malloc_has_succeeded("heredoc expander", tmpstr);
 	*result = strjoin_and_free_both(*result, tmpstr);
 	check_malloc_has_succeeded("heredoc expander", *result);
 	*str += *len + 1;
-	// バックスラッシュの次の文字を繋げる
 	tmpstr = ft_substr(*str, 0, 1);
 	check_malloc_has_succeeded("heredoc expander", tmpstr);
 	*result = strjoin_and_free_both(*result, tmpstr);
@@ -33,8 +31,8 @@ static void process_escape(char **result, char **str, int *len)
 char	*expand_heredoc_document(char *str)
 {
 	char	*result;
-	int		len;  // 現在見ている範囲の長さ. 先頭は*strを直接動かす
-	bool	is_in_env;  // 現在環境変数にいるか
+	int		len;
+	bool	is_in_env;
 	bool	is_continue;
 
 	result = ft_strdup("");
@@ -44,14 +42,13 @@ char	*expand_heredoc_document(char *str)
 	is_in_env = false;
 	while (is_continue)
 	{
-		// エスケープの処理
 		if (str[len] == '\\')
 		{
 			if (is_in_env)
-				is_continue = exp_join_str_or_env(&result, &str, &len, &is_in_env);
+				is_continue = exp_join_str_or_env(&result, &str, &len,
+						&is_in_env);
 			process_escape(&result, &str, &len);
 		}
-		// ドルマーク($) 環境変数開始の処理
 		else if (exp_will_toggle_env(is_in_env, false, str, len))
 			is_continue = exp_join_str_or_env(&result, &str, &len, &is_in_env);
 		else

--- a/interactive_shell.c
+++ b/interactive_shell.c
@@ -54,8 +54,10 @@ int	interactive_shell(void)
 			set_status(1);
 		}
 		else
+		{
 			execute_seqcmd(cmdline);
-		parse_free_all_ast();
+			parse_free_all_ast();
+		}
 		free(input_str);
 		input_str = readline(MINISHELL_PROMPT);
 	}

--- a/minishell.c
+++ b/minishell.c
@@ -37,10 +37,11 @@ int	invoke_sequential_commands(t_parse_ast *seqcmd)
 		inv = cmd_ast_pipcmds2cmdinvo(
 				seqcmd->content.sequential_commands->pipcmd_node
 				->content.piped_commands);
-		if (!inv)
-			die();
-		status = cmd_exec_commands(inv);
-		cmd_free_cmdinvo(inv);
+		if (inv)
+		{
+			status = cmd_exec_commands(inv);
+			cmd_free_cmdinvo(inv);
+		}
 		seqcmd = seqcmd->content.sequential_commands->rest_node;
 	}
 	return (status);

--- a/minishell.h
+++ b/minishell.h
@@ -31,7 +31,8 @@ typedef void	(*t_sighandler)(int);
 
 t_command_invocation	*cmd_ast_pipcmds2cmdinvo(t_parse_node_pipcmds *pipcmds);
 t_command_invocation	*cmd_ast_cmd2cmdinvo(t_parse_node_command *cmd_node);
-char					*string_node2string(t_parse_node_string *string_node, bool add_quotes);
+char					*string_node2string(t_parse_node_string *string_node,
+							bool add_quotes);
 char					**expand_string_node(t_parse_node_string *string_node);
 char					**split_expanded_str(char *str);
 char					**expand_string_node(t_parse_node_string *string_node);

--- a/minishell.h
+++ b/minishell.h
@@ -31,7 +31,7 @@ typedef void	(*t_sighandler)(int);
 
 t_command_invocation	*cmd_ast_pipcmds2cmdinvo(t_parse_node_pipcmds *pipcmds);
 t_command_invocation	*cmd_ast_cmd2cmdinvo(t_parse_node_command *cmd_node);
-char					*expand_strnode4red(t_parse_node_string *string_node);
+char					*string_node2string(t_parse_node_string *string_node);
 char					**expand_string_node(t_parse_node_string *string_node);
 char					**split_expanded_str(char *str);
 char					**expand_string_node(t_parse_node_string *string_node);

--- a/minishell.h
+++ b/minishell.h
@@ -45,6 +45,7 @@ int						put_minish_err_msg_and_ret(int ret_val,
 							const char *cmd_name, const char *msg);
 void					put_minish_err_msg_and_exit(int status,
 							const char *cmd_name, const char *msg);
+void					check_malloc_has_succeeded(char *cmd_name, void *ptr);
 int						invoke_sequential_commands(t_parse_ast *seqcmd);
 int						interactive_shell(void);
 

--- a/minishell.h
+++ b/minishell.h
@@ -31,7 +31,7 @@ typedef void	(*t_sighandler)(int);
 
 t_command_invocation	*cmd_ast_pipcmds2cmdinvo(t_parse_node_pipcmds *pipcmds);
 t_command_invocation	*cmd_ast_cmd2cmdinvo(t_parse_node_command *cmd_node);
-char					*string_node2string(t_parse_node_string *string_node);
+char					*string_node2string(t_parse_node_string *string_node, bool is_add_quotes);
 char					**expand_string_node(t_parse_node_string *string_node);
 char					**split_expanded_str(char *str);
 char					**expand_string_node(t_parse_node_string *string_node);

--- a/minishell.h
+++ b/minishell.h
@@ -14,6 +14,7 @@ typedef struct s_shell {
 	t_var				*vars;
 	int					status;
 	int					signal_child_received;
+	int					heredoc_interruption;
 }				t_shell;
 extern t_shell	g_shell;
 

--- a/minishell.h
+++ b/minishell.h
@@ -31,7 +31,7 @@ typedef void	(*t_sighandler)(int);
 
 t_command_invocation	*cmd_ast_pipcmds2cmdinvo(t_parse_node_pipcmds *pipcmds);
 t_command_invocation	*cmd_ast_cmd2cmdinvo(t_parse_node_command *cmd_node);
-char					*string_node2string(t_parse_node_string *string_node, bool is_add_quotes);
+char					*string_node2string(t_parse_node_string *string_node, bool add_quotes);
 char					**expand_string_node(t_parse_node_string *string_node);
 char					**split_expanded_str(char *str);
 char					**expand_string_node(t_parse_node_string *string_node);

--- a/minishell.h
+++ b/minishell.h
@@ -31,7 +31,7 @@ typedef void	(*t_sighandler)(int);
 
 t_command_invocation	*cmd_ast_pipcmds2cmdinvo(t_parse_node_pipcmds *pipcmds);
 t_command_invocation	*cmd_ast_cmd2cmdinvo(t_parse_node_command *cmd_node);
-char					*string_node2string(t_parse_node_string *string_node);
+char					*expand_strnode4red(t_parse_node_string *string_node);
 char					**expand_string_node(t_parse_node_string *string_node);
 char					**split_expanded_str(char *str);
 char					**expand_string_node(t_parse_node_string *string_node);

--- a/minishell_error_msg.c
+++ b/minishell_error_msg.c
@@ -36,3 +36,14 @@ void	put_minish_err_msg_and_exit(int status,
 	put_minish_err_msg(cmd_name, msg);
 	exit(status);
 }
+
+void	check_malloc_has_succeeded(char *cmd_name, void *ptr)
+{
+	if (!ptr)
+	{
+		if (cmd_name)
+			put_minish_err_msg_and_exit(1, cmd_name, "failed");
+		else
+			put_minish_err_msg_and_exit(1, "malloc", "failed");
+	}
+}

--- a/minishell_error_msg.c
+++ b/minishell_error_msg.c
@@ -42,8 +42,8 @@ void	check_malloc_has_succeeded(char *cmd_name, void *ptr)
 	if (!ptr)
 	{
 		if (cmd_name)
-			put_minish_err_msg_and_exit(1, cmd_name, "failed");
+			put_minish_err_msg_and_exit(1, cmd_name, "malloc() failed");
 		else
-			put_minish_err_msg_and_exit(1, "malloc", "failed");
+			put_minish_err_msg_and_exit(1, "malloc", "malloc() failed");
 	}
 }

--- a/parse_utils2.c
+++ b/parse_utils2.c
@@ -26,6 +26,7 @@ void	parse_free_all_ast(void)
 	t_parse_ast_list	*next;
 
 	list = *get_ast_list();
+	parse_free_heredocs(list->ast.heredocs);
 	while (list)
 	{
 		next = list->next;

--- a/string_node2string.c
+++ b/string_node2string.c
@@ -2,26 +2,25 @@
 #include "utils.h"
 
 /*
- * Convert AST string node to string for redirection.
+ * Convert AST string node to string.
  * TODO: 環境変数展開はここでする
  */
-char	*expand_strnode4red(t_parse_node_string *string_node)
+char	*string_node2string(t_parse_node_string *string_node)
 {
 	char	*result;
 
 	result = ft_strdup("");
-	if (!result)
-		put_minish_err_msg_and_exit(1, "string_node2string_for_red()",
-			"malloc() failed");
 	while (string_node)
 	{
 		if (string_node->type == TOKTYPE_NON_EXPANDABLE)
-			result = strjoin_and_free_first(result, string_node->text);
-		else
-			result = expand_env_var(string_node->text);
-		if (!result)
-			put_minish_err_msg_and_exit(1, "string_node2string_for_red()",
-				"malloc() failed");
+			result = strjoin_and_free_first(result, "\'");
+		else if (string_node->type == TOKTYPE_EXPANDABLE_QUOTED)
+			result = strjoin_and_free_first(result, "\"");
+		result = strjoin_and_free_first(result, string_node->text);
+		if (string_node->type == TOKTYPE_NON_EXPANDABLE)
+			result = strjoin_and_free_first(result, "\'");
+		else if (string_node->type == TOKTYPE_EXPANDABLE_QUOTED)
+			result = strjoin_and_free_first(result, "\"");
 		if (string_node->next)
 			string_node = string_node->next->content.string;
 		else

--- a/string_node2string.c
+++ b/string_node2string.c
@@ -4,21 +4,21 @@
 /*
  * Convert AST string node to string.
  */
-char	*string_node2string(t_parse_node_string *string_node)
+char	*string_node2string(t_parse_node_string *string_node, bool is_add_quotes)
 {
 	char	*result;
 
 	result = ft_strdup("");
 	while (string_node)
 	{
-		if (string_node->type == TOKTYPE_NON_EXPANDABLE)
+		if (is_add_quotes && string_node->type == TOKTYPE_NON_EXPANDABLE)
 			result = strjoin_and_free_first(result, "\'");
-		else if (string_node->type == TOKTYPE_EXPANDABLE_QUOTED)
+		else if (is_add_quotes && string_node->type == TOKTYPE_EXPANDABLE_QUOTED)
 			result = strjoin_and_free_first(result, "\"");
 		result = strjoin_and_free_first(result, string_node->text);
-		if (string_node->type == TOKTYPE_NON_EXPANDABLE)
+		if (is_add_quotes && string_node->type == TOKTYPE_NON_EXPANDABLE)
 			result = strjoin_and_free_first(result, "\'");
-		else if (string_node->type == TOKTYPE_EXPANDABLE_QUOTED)
+		else if (is_add_quotes && string_node->type == TOKTYPE_EXPANDABLE_QUOTED)
 			result = strjoin_and_free_first(result, "\"");
 		if (string_node->next)
 			string_node = string_node->next->content.string;

--- a/string_node2string.c
+++ b/string_node2string.c
@@ -1,6 +1,12 @@
 #include "minishell.h"
 #include "utils.h"
 
+static void	string_node2string_malloc_check(char *result)
+{
+	if (!result)
+		put_minish_err_msg_and_exit(1, "strnode2str", "malloc() failed");
+}
+
 /*
  * Convert AST string node to string.
  */
@@ -9,17 +15,21 @@ char	*string_node2string(t_parse_node_string *string_node, bool is_add_quotes)
 	char	*result;
 
 	result = ft_strdup("");
+	string_node2string_malloc_check(result);
 	while (string_node)
 	{
 		if (is_add_quotes && string_node->type == TOKTYPE_NON_EXPANDABLE)
 			result = strjoin_and_free_first(result, "\'");
 		else if (is_add_quotes && string_node->type == TOKTYPE_EXPANDABLE_QUOTED)
 			result = strjoin_and_free_first(result, "\"");
+		string_node2string_malloc_check(result);
 		result = strjoin_and_free_first(result, string_node->text);
+		string_node2string_malloc_check(result);
 		if (is_add_quotes && string_node->type == TOKTYPE_NON_EXPANDABLE)
 			result = strjoin_and_free_first(result, "\'");
 		else if (is_add_quotes && string_node->type == TOKTYPE_EXPANDABLE_QUOTED)
 			result = strjoin_and_free_first(result, "\"");
+		string_node2string_malloc_check(result);
 		if (string_node->next)
 			string_node = string_node->next->content.string;
 		else

--- a/string_node2string.c
+++ b/string_node2string.c
@@ -10,7 +10,8 @@ static void	string_node2string_malloc_check(char *result)
 /*
  * Convert AST string node to string.
  */
-char	*string_node2string(t_parse_node_string *string_node, bool is_add_quotes)
+char	*string_node2string(t_parse_node_string *string_node,
+	bool add_quotes)
 {
 	char	*result;
 
@@ -18,16 +19,16 @@ char	*string_node2string(t_parse_node_string *string_node, bool is_add_quotes)
 	string_node2string_malloc_check(result);
 	while (string_node)
 	{
-		if (is_add_quotes && string_node->type == TOKTYPE_NON_EXPANDABLE)
+		if (add_quotes && string_node->type == TOKTYPE_NON_EXPANDABLE)
 			result = strjoin_and_free_first(result, "\'");
-		else if (is_add_quotes && string_node->type == TOKTYPE_EXPANDABLE_QUOTED)
+		else if (add_quotes && string_node->type == TOKTYPE_EXPANDABLE_QUOTED)
 			result = strjoin_and_free_first(result, "\"");
 		string_node2string_malloc_check(result);
 		result = strjoin_and_free_first(result, string_node->text);
 		string_node2string_malloc_check(result);
-		if (is_add_quotes && string_node->type == TOKTYPE_NON_EXPANDABLE)
+		if (add_quotes && string_node->type == TOKTYPE_NON_EXPANDABLE)
 			result = strjoin_and_free_first(result, "\'");
-		else if (is_add_quotes && string_node->type == TOKTYPE_EXPANDABLE_QUOTED)
+		else if (add_quotes && string_node->type == TOKTYPE_EXPANDABLE_QUOTED)
 			result = strjoin_and_free_first(result, "\"");
 		string_node2string_malloc_check(result);
 		if (string_node->next)

--- a/string_node2string.c
+++ b/string_node2string.c
@@ -3,6 +3,7 @@
 
 /*
  * Convert AST string node to string.
+ * TODO: 環境変数展開はここでする
  */
 char	*string_node2string(t_parse_node_string *string_node)
 {

--- a/string_node2string.c
+++ b/string_node2string.c
@@ -2,25 +2,26 @@
 #include "utils.h"
 
 /*
- * Convert AST string node to string.
+ * Convert AST string node to string for redirection.
  * TODO: 環境変数展開はここでする
  */
-char	*string_node2string(t_parse_node_string *string_node)
+char	*expand_strnode4red(t_parse_node_string *string_node)
 {
 	char	*result;
 
 	result = ft_strdup("");
+	if (!result)
+		put_minish_err_msg_and_exit(1, "string_node2string_for_red()",
+			"malloc() failed");
 	while (string_node)
 	{
 		if (string_node->type == TOKTYPE_NON_EXPANDABLE)
-			result = strjoin_and_free_first(result, "\'");
-		else if (string_node->type == TOKTYPE_EXPANDABLE_QUOTED)
-			result = strjoin_and_free_first(result, "\"");
-		result = strjoin_and_free_first(result, string_node->text);
-		if (string_node->type == TOKTYPE_NON_EXPANDABLE)
-			result = strjoin_and_free_first(result, "\'");
-		else if (string_node->type == TOKTYPE_EXPANDABLE_QUOTED)
-			result = strjoin_and_free_first(result, "\"");
+			result = strjoin_and_free_first(result, string_node->text);
+		else
+			result = expand_env_var(string_node->text);
+		if (!result)
+			put_minish_err_msg_and_exit(1, "string_node2string_for_red()",
+				"malloc() failed");
 		if (string_node->next)
 			string_node = string_node->next->content.string;
 		else

--- a/string_node2string.c
+++ b/string_node2string.c
@@ -1,12 +1,6 @@
 #include "minishell.h"
 #include "utils.h"
 
-static void	string_node2string_malloc_check(char *result)
-{
-	if (!result)
-		put_minish_err_msg_and_exit(1, "strnode2str", "malloc() failed");
-}
-
 /*
  * Convert AST string node to string.
  */
@@ -16,21 +10,21 @@ char	*string_node2string(t_parse_node_string *string_node,
 	char	*result;
 
 	result = ft_strdup("");
-	string_node2string_malloc_check(result);
+	check_malloc_has_succeeded("string_node2string", result);
 	while (string_node)
 	{
 		if (add_quotes && string_node->type == TOKTYPE_NON_EXPANDABLE)
 			result = strjoin_and_free_first(result, "\'");
 		else if (add_quotes && string_node->type == TOKTYPE_EXPANDABLE_QUOTED)
 			result = strjoin_and_free_first(result, "\"");
-		string_node2string_malloc_check(result);
+		check_malloc_has_succeeded("string_node2string", result);
 		result = strjoin_and_free_first(result, string_node->text);
-		string_node2string_malloc_check(result);
+		check_malloc_has_succeeded("string_node2string", result);
 		if (add_quotes && string_node->type == TOKTYPE_NON_EXPANDABLE)
 			result = strjoin_and_free_first(result, "\'");
 		else if (add_quotes && string_node->type == TOKTYPE_EXPANDABLE_QUOTED)
 			result = strjoin_and_free_first(result, "\"");
-		string_node2string_malloc_check(result);
+		check_malloc_has_succeeded("string_node2string", result);
 		if (string_node->next)
 			string_node = string_node->next->content.string;
 		else

--- a/string_node2string.c
+++ b/string_node2string.c
@@ -3,7 +3,6 @@
 
 /*
  * Convert AST string node to string.
- * TODO: 環境変数展開はここでする
  */
 char	*string_node2string(t_parse_node_string *string_node)
 {

--- a/test/Makefile
+++ b/test/Makefile
@@ -3,7 +3,8 @@ LIBFT_MAKE = $(MAKE) -C $(LIBFT_PATH)
 LIBFT_LIB = ../libft/libft.a
 LDFLAGS = -lreadline
 SRCFILES = cmd_cmd_invocation.c cmd_cmd_invocation2.c cmd_exec_command.c	\
-	cmd_exec_commands.c cmd_pipe.c cmd_redirection.c convert_ast2cmdinvo.c	\
+	cmd_exec_commands.c cmd_pipe.c cmd_redirection.c cmd_heredoc_funcs.c	\
+	convert_ast2cmdinvo.c													\
 	cmd_status.c signal.c env_setter.c minishell_error_msg.c env.c exec.c	\
 	cmd_exec_builtin.c														\
 																			\

--- a/test/Makefile
+++ b/test/Makefile
@@ -14,8 +14,8 @@ SRCFILES = cmd_cmd_invocation.c cmd_cmd_invocation2.c cmd_exec_command.c	\
 	path.c g_cwd.c string_node2string.c env_expander.c heredoc_expander.c	\
 	expand_string_node.c split_expanded_str.c t_var.c t_var2.c				\
 																			\
-	builtin.c builtin_echo.c builtin_env.c builtin_exit.c builtin_cd.c		\
-	builtin_cd_path.c builtin_cd_chdir.c builtin_cd_cdpath.c				\
+	builtin.c  builtin_fd_list.c builtin_echo.c builtin_env.c builtin_exit.c\
+	builtin_cd.c builtin_cd_path.c builtin_cd_chdir.c builtin_cd_cdpath.c	\
 	builtin_export.c builtin_export2.c builtin_pwd.c builtin_unset.c		\
 																			\
 	str_utils.c shell_initialization.c

--- a/test/Makefile
+++ b/test/Makefile
@@ -11,7 +11,7 @@ SRCFILES = cmd_cmd_invocation.c cmd_cmd_invocation2.c cmd_exec_command.c	\
 	lexer1.c lexer2.c lexer3.c lexer4.c parse1.c parse2.c parse3.c			\
 	parse_utils.c parse_utils2.c											\
 																			\
-	path.c g_cwd.c string_node2string.c expand_env_var.c					\
+	path.c g_cwd.c string_node2string.c env_expander.c heredoc_expander.c	\
 	expand_string_node.c split_expanded_str.c t_var.c t_var2.c				\
 																			\
 	builtin.c builtin_echo.c builtin_env.c builtin_exit.c builtin_cd.c		\

--- a/test/ast2cmdinvo_test.c
+++ b/test/ast2cmdinvo_test.c
@@ -271,7 +271,7 @@ int main()
 		string_node = string_node->next->content.string;
 		CHECK_EQ(string_node->type, TOKTYPE_NON_EXPANDABLE);
 		CHECK_EQ_STR(string_node->text, "$ABC");
-		char *expanded_str = string_node2string(args_node->string_node->content.string);
+		char *expanded_str = string_node2string(args_node->string_node->content.string, true);
 		printf("expanded: %s\n", expanded_str);
 		CHECK_EQ_STR(expanded_str, "hoge$ABC\"hoge hoge\"'$ABC'");
 		free(expanded_str);
@@ -529,7 +529,7 @@ int main()
 		/* テスト */
 		t_command_invocation *actual = cmd_ast_cmd2cmdinvo(node->content.command);
 		t_command_invocation *expected = cmd_init_cmdinvo((const char **)ft_split("file", ' '));
-		cmd_add_inredirect(expected, ft_strdup("abc"), 0);
+		cmd_add_inredirect(expected, "abc", 0);
 		CHECK(actual);
 		check_cmdinvo(actual, expected);
 
@@ -554,7 +554,7 @@ int main()
 		/* テスト */
 		t_command_invocation *actual = cmd_ast_cmd2cmdinvo(node->content.command);
 		t_command_invocation *expected = cmd_init_cmdinvo((const char **)ft_split("file", ' '));
-		cmd_add_inredirect(expected, ft_strdup("abc"), 123);
+		cmd_add_inredirect(expected, "abc", 123);
 		CHECK(actual);
 		check_cmdinvo(actual, expected);
 
@@ -579,7 +579,7 @@ int main()
 		/* テスト */
 		t_command_invocation *actual = cmd_ast_cmd2cmdinvo(node->content.command);
 		t_command_invocation *expected = cmd_init_cmdinvo((const char **)ft_split("file", ' '));
-		cmd_add_outredirect(expected, ft_strdup("abc"), 1, false);
+		cmd_add_outredirect(expected, "abc", 1, false);
 		CHECK(actual);
 		check_cmdinvo(actual, expected);
 
@@ -604,7 +604,7 @@ int main()
 		/* テスト */
 		t_command_invocation *actual = cmd_ast_cmd2cmdinvo(node->content.command);
 		t_command_invocation *expected = cmd_init_cmdinvo((const char **)ft_split("file", ' '));
-		cmd_add_outredirect(expected, ft_strdup("abc"), 123, false);
+		cmd_add_outredirect(expected, "abc", 123, false);
 		CHECK(actual);
 		check_cmdinvo(actual, expected);
 
@@ -629,8 +629,8 @@ int main()
 		/* テスト */
 		t_command_invocation *actual = cmd_ast_cmd2cmdinvo(node->content.command);
 		t_command_invocation *expected = cmd_init_cmdinvo((const char **)ft_split("file", ' '));
-		cmd_add_inredirect(expected, ft_strdup("input"), 0);
-		cmd_add_outredirect(expected, ft_strdup("output"), 1, false);
+		cmd_add_inredirect(expected, "input", 0);
+		cmd_add_outredirect(expected, "output", 1, false);
 		CHECK(actual);
 		check_cmdinvo(actual, expected);
 
@@ -655,7 +655,7 @@ int main()
 		/* テスト */
 		t_command_invocation *actual = cmd_ast_cmd2cmdinvo(node->content.command);
 		t_command_invocation *expected = cmd_init_cmdinvo((const char **)ft_split("file", ' '));
-		cmd_add_outredirect(expected, ft_strdup("abc"), 1, true);
+		cmd_add_outredirect(expected, "abc", 1, true);
 		CHECK(actual);
 		check_cmdinvo(actual, expected);
 
@@ -680,7 +680,7 @@ int main()
 		/* テスト */
 		t_command_invocation *actual = cmd_ast_cmd2cmdinvo(node->content.command);
 		t_command_invocation *expected = cmd_init_cmdinvo((const char **)ft_split("file", ' '));
-		cmd_add_outredirect(expected, ft_strdup("abc"), 456, true);
+		cmd_add_outredirect(expected, "abc", 456, true);
 		CHECK(actual);
 		check_cmdinvo(actual, expected);
 
@@ -706,10 +706,10 @@ int main()
 		/* テスト */
 		t_command_invocation *actual = cmd_ast_cmd2cmdinvo(node->content.command);
 		t_command_invocation *expected = cmd_init_cmdinvo((const char **)ft_split("file", ' '));
-		cmd_add_inredirect(expected, ft_strdup("a"), 0);
-		cmd_add_inredirect(expected, ft_strdup("b"), 0);
-		cmd_add_inredirect(expected, ft_strdup("c"), 0);
-		cmd_add_inredirect(expected, ft_strdup("d"), 0);
+		cmd_add_inredirect(expected, "a", 0);
+		cmd_add_inredirect(expected, "b", 0);
+		cmd_add_inredirect(expected, "c", 0);
+		cmd_add_inredirect(expected, "d", 0);
 		CHECK(actual);
 		check_cmdinvo(actual, expected);
 
@@ -734,10 +734,10 @@ int main()
 		/* テスト */
 		t_command_invocation *actual = cmd_ast_cmd2cmdinvo(node->content.command);
 		t_command_invocation *expected = cmd_init_cmdinvo((const char **)ft_split("file", ' '));
-		cmd_add_outredirect(expected, ft_strdup("a"), 1, false);
-		cmd_add_outredirect(expected, ft_strdup("b"), 1, false);
-		cmd_add_outredirect(expected, ft_strdup("c"), 1, false);
-		cmd_add_outredirect(expected, ft_strdup("d"), 1, false);
+		cmd_add_outredirect(expected, "a", 1, false);
+		cmd_add_outredirect(expected, "b", 1, false);
+		cmd_add_outredirect(expected, "c", 1, false);
+		cmd_add_outredirect(expected, "d", 1, false);
 		CHECK(actual);
 		check_cmdinvo(actual, expected);
 
@@ -762,10 +762,10 @@ int main()
 		/* テスト */
 		t_command_invocation *actual = cmd_ast_cmd2cmdinvo(node->content.command);
 		t_command_invocation *expected = cmd_init_cmdinvo((const char **)ft_split("file", ' '));
-		cmd_add_outredirect(expected, ft_strdup("a"), 1, true);
-		cmd_add_outredirect(expected, ft_strdup("b"), 1, true);
-		cmd_add_outredirect(expected, ft_strdup("c"), 1, true);
-		cmd_add_outredirect(expected, ft_strdup("d"), 1, true);
+		cmd_add_outredirect(expected, "a", 1, true);
+		cmd_add_outredirect(expected, "b", 1, true);
+		cmd_add_outredirect(expected, "c", 1, true);
+		cmd_add_outredirect(expected, "d", 1, true);
 		CHECK(actual);
 		check_cmdinvo(actual, expected);
 
@@ -790,10 +790,10 @@ int main()
 		/* テスト */
 		t_command_invocation *actual = cmd_ast_cmd2cmdinvo(node->content.command);
 		t_command_invocation *expected = cmd_init_cmdinvo((const char **)ft_split("file", ' '));
-		cmd_add_inredirect(expected, ft_strdup("a"), 0);
-		cmd_add_inredirect(expected, ft_strdup("b"), 0);
-		cmd_add_outredirect(expected, ft_strdup("c"), 1, false);
-		cmd_add_outredirect(expected, ft_strdup("d"), 1, false);
+		cmd_add_inredirect(expected, "a", 0);
+		cmd_add_inredirect(expected, "b", 0);
+		cmd_add_outredirect(expected, "c", 1, false);
+		cmd_add_outredirect(expected, "d", 1, false);
 		CHECK(actual);
 		check_cmdinvo(actual, expected);
 
@@ -1079,7 +1079,7 @@ int main()
 		/* テスト */
 		t_command_invocation *actual = cmd_ast_cmd2cmdinvo(node->content.command);
 		t_command_invocation *expected = cmd_init_cmdinvo((const char **)ft_split("echo hello", ' '));
-		cmd_add_outredirect(expected, ft_strdup("$ABC"), 1, false);
+		cmd_add_outredirect(expected, "$ABC", 1, false);
 		CHECK(actual);
 		check_cmdinvo(actual, expected);
 
@@ -1122,7 +1122,7 @@ int main()
 		/* テスト */
 		t_command_invocation *actual = cmd_ast_cmd2cmdinvo(node->content.command);
 		t_command_invocation *expected = cmd_init_cmdinvo((const char **)ft_split("echo hello", ' '));
-		cmd_add_outredirect(expected, ft_strdup("hoge$ABC"), 1, false);
+		cmd_add_outredirect(expected, "hoge$ABC", 1, false);
 		CHECK(actual);
 		check_cmdinvo(actual, expected);
 
@@ -1230,7 +1230,7 @@ int main()
 		t_command_invocation *actual = cmd_ast_pipcmds2cmdinvo(node->content.piped_commands);
 		t_command_invocation *expected_first = cmd_init_cmdinvo((const char **)ft_split("abc", ' '));
 		t_command_invocation *expected_second = cmd_init_cmdinvo((const char **)ft_split("file", ' '));
-		cmd_add_inredirect(expected_second, ft_strdup("abc"), 0);
+		cmd_add_inredirect(expected_second, "abc", 0);
 		expected_first->piped_command = expected_second;
 
 		CHECK(actual);
@@ -1257,7 +1257,7 @@ int main()
 		t_command_invocation *actual = cmd_ast_pipcmds2cmdinvo(node->content.piped_commands);
 		t_command_invocation *expected_first = cmd_init_cmdinvo((const char **)ft_split("abc", ' '));
 		t_command_invocation *expected_second = cmd_init_cmdinvo((const char **)ft_split("file", ' '));
-		cmd_add_outredirect(expected_second, ft_strdup("abc"), 1, false);
+		cmd_add_outredirect(expected_second, "abc", 1, false);
 		expected_first->piped_command = expected_second;
 
 		CHECK(actual);

--- a/test/ast2cmdinvo_test.c
+++ b/test/ast2cmdinvo_test.c
@@ -271,7 +271,7 @@ int main()
 		string_node = string_node->next->content.string;
 		CHECK_EQ(string_node->type, TOKTYPE_NON_EXPANDABLE);
 		CHECK_EQ_STR(string_node->text, "$ABC");
-		char *expanded_str = string_node2string_for_red(args_node->string_node->content.string);
+		char *expanded_str = string_node2string(args_node->string_node->content.string);
 		printf("expanded: %s\n", expanded_str);
 		CHECK_EQ_STR(expanded_str, "hoge$ABC\"hoge hoge\"'$ABC'");
 		free(expanded_str);

--- a/test/ast2cmdinvo_test.c
+++ b/test/ast2cmdinvo_test.c
@@ -242,6 +242,48 @@ int main()
 		unsetenv("ABC");
 	}
 
+	/* bash での出力を元としたテストケース
+	 *
+	 * $ cat << HOGE
+	 * > \$USER
+	 * > "\$USER"
+	 * > '$USER'
+	 * > $USER
+	 * > $\USER
+	 * > \"\'\$\\
+	 * $USER
+	 * "$USER"
+	 * 'jun'
+	 * jun
+	 * $\USER
+	 * \"\'$\
+	 */
+	TEST_SECTION("expand_heredoc_document() 普通文字と各種記号とバックスラッシュ\n");
+	{
+		ft_setenv("USER", "jun", 0);
+		set_status(0);
+		char *input = ft_strdup(
+			"\\$USER\n"
+			"\"\\$USER\"\n"
+			"'$USER'\n"
+			"$USER\n"
+			"$\\USER\n"
+			"\\\"\\'\\$\\\\\n"
+			);
+		char *actual = expand_heredoc_document(input);
+		char *expected =
+			"$USER\n"
+			"\"$USER\"\n"
+			"'jun'\n"
+			"jun\n"
+			"$\\USER\n"
+			"\\\"\\\'$\\\n";
+		CHECK_EQ_STR(actual, expected);
+		free(input);
+		free(actual);
+		unsetenv("ABC");
+	}
+
 	TEST_SECTION("string_node2string()");
 	{
 		/* 準備 */

--- a/test/ast2cmdinvo_test.c
+++ b/test/ast2cmdinvo_test.c
@@ -271,7 +271,7 @@ int main()
 		string_node = string_node->next->content.string;
 		CHECK_EQ(string_node->type, TOKTYPE_NON_EXPANDABLE);
 		CHECK_EQ_STR(string_node->text, "$ABC");
-		char *expanded_str = string_node2string(args_node->string_node->content.string);
+		char *expanded_str = string_node2string_for_red(args_node->string_node->content.string);
 		printf("expanded: %s\n", expanded_str);
 		CHECK_EQ_STR(expanded_str, "hoge$ABC\"hoge hoge\"'$ABC'");
 		free(expanded_str);

--- a/test/command_exec_test.c
+++ b/test/command_exec_test.c
@@ -19,7 +19,7 @@ int main(){
     TEST_SECTION("cat /etc/passwd > output.txt");
     {
 		t_command_invocation *command = cmd_init_cmdinvo((const char**)ft_split("cat /etc/passwd", ' '));
-		cmd_add_outredirect(command, ft_strdup("output.txt"), 1, false);
+		cmd_add_outredirect(command, "output.txt", 1, false);
 
 		int status = cmd_exec_commands(command);
 		CHECK_EQ(status, 0);
@@ -32,7 +32,7 @@ int main(){
     {
 		system("echo aaaaaaaaaaaaaaaaaaaaaaaaaaaaa > output.txt ; cp output.txt expected.txt ; echo hello > expected.txt");
 		t_command_invocation *command = cmd_init_cmdinvo((const char**)ft_split("echo hello", ' '));
-		cmd_add_outredirect(command, ft_strdup("output.txt"), 1, false);
+		cmd_add_outredirect(command, "output.txt", 1, false);
 
 		int status = cmd_exec_commands(command);
 		CHECK_EQ(status, 0);
@@ -44,7 +44,7 @@ int main(){
     TEST_SECTION("/usr/bin/cat /etc/passwd > output.txt");
     {
 		t_command_invocation *command = cmd_init_cmdinvo((const char**)ft_split("/usr/bin/cat /etc/passwd", ' '));
-		cmd_add_outredirect(command, ft_strdup("output.txt"), 1, false);
+		cmd_add_outredirect(command, "output.txt", 1, false);
 
 		int status = cmd_exec_commands(command);
 		CHECK_EQ(status, 0);
@@ -57,7 +57,7 @@ int main(){
     {
 		system("echo abc > actual.txt");
 		t_command_invocation *command = cmd_init_cmdinvo((const char**)ft_split("echo def", ' '));
-		cmd_add_outredirect(command, ft_strdup("actual.txt"), 1, true);
+		cmd_add_outredirect(command, "actual.txt", 1, true);
 
 		int status = cmd_exec_commands(command);
 		CHECK_EQ(status, 0);
@@ -71,7 +71,7 @@ int main(){
     TEST_SECTION("cat < Makefile");
     {
 		t_command_invocation *command = cmd_init_cmdinvo((const char**)ft_split("cat", ' '));
-		cmd_add_inredirect(command, ft_strdup("Makefile"), 0);
+		cmd_add_inredirect(command, "Makefile", 0);
 
 		int status = cmd_exec_commands(command);
 		CHECK_EQ(status, 0);
@@ -81,7 +81,7 @@ int main(){
     TEST_SECTION("/usr/bin/cat < Makefile");
     {
 		t_command_invocation *command = cmd_init_cmdinvo((const char**)ft_split("/usr/bin/cat", ' '));
-		cmd_add_inredirect(command, ft_strdup("Makefile"), 0);
+		cmd_add_inredirect(command, "Makefile", 0);
 
 		int status = cmd_exec_commands(command);
 		CHECK_EQ(status, 0);
@@ -91,7 +91,7 @@ int main(){
     TEST_SECTION("cat < not_exists  存在しないファイルを入力リダイレクトするとエラー");
     {
 		t_command_invocation *command = cmd_init_cmdinvo((const char**)ft_split("cat", ' '));
-		cmd_add_inredirect(command, ft_strdup("not_exists"), 0);
+		cmd_add_inredirect(command, "not_exists", 0);
 
 		int status = cmd_exec_commands(command);
 		CHECK(status != 0);
@@ -101,8 +101,8 @@ int main(){
     TEST_SECTION("cat < test.h > output.txt");
     {
 		t_command_invocation *command = cmd_init_cmdinvo((const char**)ft_split("cat", ' '));
-		cmd_add_inredirect(command, ft_strdup("test.h"), 0);
-		cmd_add_outredirect(command, ft_strdup("output.txt"), 1, false);
+		cmd_add_inredirect(command, "test.h", 0);
+		cmd_add_outredirect(command, "output.txt", 1, false);
 
 		int status = cmd_exec_commands(command);
 		CHECK_EQ(status, 0);
@@ -114,8 +114,8 @@ int main(){
     TEST_SECTION("cat Makefile > a > b  出力リダイレクトが複数");
     {
 		t_command_invocation *command = cmd_init_cmdinvo((const char**)ft_split("cat Makefile", ' '));
-		cmd_add_outredirect(command, ft_strdup("actual_a"), 1, false);
-		cmd_add_outredirect(command, ft_strdup("actual_b"), 1, false);
+		cmd_add_outredirect(command, "actual_a", 1, false);
+		cmd_add_outredirect(command, "actual_b", 1, false);
 
 		int status = cmd_exec_commands(command);
 		CHECK_EQ(status, 0);
@@ -131,9 +131,9 @@ int main(){
     TEST_SECTION("cat < Makefile < test.h > output.txt  入力リダイレクトが複数");
     {
 		t_command_invocation *command = cmd_init_cmdinvo((const char**)ft_split("cat", ' '));
-		cmd_add_inredirect(command, ft_strdup("Makefile"), 0);
-		cmd_add_inredirect(command, ft_strdup("test.h"), 0);
-		cmd_add_outredirect(command, ft_strdup("output.txt"), 1, false);
+		cmd_add_inredirect(command, "Makefile", 0);
+		cmd_add_inredirect(command, "test.h", 0);
+		cmd_add_outredirect(command, "output.txt", 1, false);
 
 		int status = cmd_exec_commands(command);
 		CHECK_EQ(status, 0);
@@ -148,8 +148,8 @@ int main(){
     {
 		system("echo ThisIsA > actual_a ; echo ThisIsB > actual_b");
 		t_command_invocation *command = cmd_init_cmdinvo((const char**)ft_split("cat Makefile", ' '));
-		cmd_add_outredirect(command, ft_strdup("actual_a"), 1, true);
-		cmd_add_outredirect(command, ft_strdup("actual_b"), 1, true);
+		cmd_add_outredirect(command, "actual_a", 1, true);
+		cmd_add_outredirect(command, "actual_b", 1, true);
 
 		int status = cmd_exec_commands(command);
 		CHECK_EQ(status, 0);
@@ -169,9 +169,9 @@ int main(){
 		system("printf '#include<unistd.h>\nint main(){write(1, \"fd1\", 3);write(2, \"fd2\", 3);write(3, \"fd3\", 3);}' > multiple_fd_out.c && gcc multiple_fd_out.c -o multiple_fd_out");
 		t_command_invocation *command = cmd_init_cmdinvo((const char **)ft_split("./multiple_fd_out", ' '));
 		// ./a.out 3> file3 2> file2 1> file1; cat file3 file2 file1
-		cmd_add_outredirect(command, ft_strdup("actual_3"), 3, true);
-		cmd_add_outredirect(command, ft_strdup("actual_2"), 2, true);
-		cmd_add_outredirect(command, ft_strdup("actual_1"), 1, true);
+		cmd_add_outredirect(command, "actual_3", 3, true);
+		cmd_add_outredirect(command, "actual_2", 2, true);
+		cmd_add_outredirect(command, "actual_1", 1, true);
 
 		int status = cmd_exec_commands(command);
 		CHECK_EQ(status, 0);
@@ -197,9 +197,9 @@ int main(){
 		t_command_invocation *command = cmd_init_cmdinvo((const char **)ft_split("./multiple_fd_in", ' '));
 		system("echo this_is_hoge > hoge && echo this_is_fuga > fuga");
 		// ./multiple_fd_in 0<hoge 3<fuga > actual
-		cmd_add_inredirect(command, ft_strdup("hoge"), 0);
-		cmd_add_inredirect(command, ft_strdup("fuga"), 3);
-		cmd_add_outredirect(command, ft_strdup("actual"), 1, true);
+		cmd_add_inredirect(command, "hoge", 0);
+		cmd_add_inredirect(command, "fuga", 3);
+		cmd_add_outredirect(command, "actual", 1, true);
 
 		int status = cmd_exec_commands(command);
 		CHECK_EQ(status, 0);
@@ -219,7 +219,7 @@ int main(){
 		t_command_invocation *first_command = cmd_init_cmdinvo((const char**)ft_split("cat /etc/passwd", ' '));
 
 		t_command_invocation *second_command = cmd_init_cmdinvo((const char**)ft_split("wc", ' '));
-		cmd_add_outredirect(second_command, ft_strdup("output.txt"), 1, false);
+		cmd_add_outredirect(second_command, "output.txt", 1, false);
 
 		cmd_cmdinvo_add_pipcmd(&first_command, second_command);
 
@@ -237,7 +237,7 @@ int main(){
 		t_command_invocation *second_command = cmd_init_cmdinvo((const char**)ft_split("wc", ' '));
 
 		t_command_invocation *third_command = cmd_init_cmdinvo((const char**)ft_split("cat", ' '));
-		cmd_add_outredirect(third_command, ft_strdup("output.txt"), 1, false);
+		cmd_add_outredirect(third_command, "output.txt", 1, false);
 
 		cmd_cmdinvo_add_pipcmd(&first_command, second_command);
 		cmd_cmdinvo_add_pipcmd(&first_command, third_command);
@@ -252,12 +252,12 @@ int main(){
     TEST_SECTION("cat /etc/passwd > /dev/null | wc | cat > output.txt  パイプの最初のコマンドでリダイレクトがある");
     {
 		t_command_invocation *first_command = cmd_init_cmdinvo((const char**)ft_split("cat /etc/passwd", ' '));
-		cmd_add_outredirect(first_command, ft_strdup("/dev/null"), 1, false);
+		cmd_add_outredirect(first_command, "/dev/null", 1, false);
 
 		t_command_invocation *second_command = cmd_init_cmdinvo((const char**)ft_split("wc", ' '));
 
 		t_command_invocation *third_command = cmd_init_cmdinvo((const char**)ft_split("cat", ' '));
-		cmd_add_outredirect(third_command, ft_strdup("output.txt"), 1, false);
+		cmd_add_outredirect(third_command, "output.txt", 1, false);
 
 		cmd_cmdinvo_add_pipcmd(&first_command, second_command);
 		cmd_cmdinvo_add_pipcmd(&first_command, third_command);
@@ -274,10 +274,10 @@ int main(){
 		t_command_invocation *first_command = cmd_init_cmdinvo((const char**)ft_split("cat test.h", ' '));
 
 		t_command_invocation *second_command = cmd_init_cmdinvo((const char**)ft_split("wc", ' '));
-		cmd_add_inredirect(second_command, ft_strdup("test.c"), 0);
+		cmd_add_inredirect(second_command, "test.c", 0);
 
 		t_command_invocation *third_command = cmd_init_cmdinvo((const char**)ft_split("cat", ' '));
-		cmd_add_outredirect(third_command, ft_strdup("output.txt"), 1, false);
+		cmd_add_outredirect(third_command, "output.txt", 1, false);
 
 		cmd_cmdinvo_add_pipcmd(&first_command, second_command);
 		cmd_cmdinvo_add_pipcmd(&first_command, third_command);
@@ -312,7 +312,7 @@ int main(){
     {
 		remove("not_exists");
 		t_command_invocation *command = cmd_init_cmdinvo((const char**)ft_split("not_exists", ' '));
-		cmd_add_outredirect(command, ft_strdup("output.txt"), 1, false);
+		cmd_add_outredirect(command, "output.txt", 1, false);
 
 		remove("output.txt");
 		int status = cmd_exec_commands(command);

--- a/test/parse_test.c
+++ b/test/parse_test.c
@@ -1312,7 +1312,6 @@ void test_parser(void)
 		check_pip_heredocument(here_node, "hij", "klm", 123);
 
 		free(tok.text);
-		parse_free_heredocs(cmdline_node->heredocs);
 	}
 
 }


### PR DESCRIPTION
Close #145 

## 実装したこと

- heredocの文字列を`readline()`を使って取得
- コマンド実行時に親プロセスから子プロセスにパイプを経由してheredocの文字列を送る.
- heredocの文字列の環境変数展開

## TODO:

- [x] heredoc入力中に `^C` が押された時の挙動.
- [x] ~heredoc を含む履歴機能~ 課題要件に書いてない
- [x] ビルドインコマンド単体の場合の実装.
- [x] 環境変数の展開