### PR TITLE
exportコマンドの時の環境変数展開の動きをbashに合わせる.

### DIFF
--- a/convert_ast2cmdinvo.c
+++ b/convert_ast2cmdinvo.c
@@ -16,7 +16,11 @@ int	cmd_process_string_node(t_parse_node_string *string_node,
 	char		**splitted_env_val;
 	const char	**strarr;
 
-	splitted_env_val = expand_string_node(string_node);
+	if (command->exec_and_args && command->exec_and_args[0]
+		&& !ft_strcmp(command->exec_and_args[0], "export"))
+		splitted_env_val = expand_string_node(string_node, true);
+	else
+		splitted_env_val = expand_string_node(string_node, false);
 	strarr = (const char **)ptrarr_merge((void **)command->exec_and_args,
 			(void **)splitted_env_val);
 	free(splitted_env_val);

--- a/minishell.h
+++ b/minishell.h
@@ -33,9 +33,9 @@ t_command_invocation	*cmd_ast_pipcmds2cmdinvo(t_parse_node_pipcmds *pipcmds);
 t_command_invocation	*cmd_ast_cmd2cmdinvo(t_parse_node_command *cmd_node);
 char					*string_node2string(t_parse_node_string *string_node,
 							bool add_quotes);
-char					**expand_string_node(t_parse_node_string *string_node);
+char					**expand_string_node(t_parse_node_string *string_node,
+							bool is_export_cmd);
 char					**split_expanded_str(char *str);
-char					**expand_string_node(t_parse_node_string *string_node);
 void					set_shell_sighandlers(void);
 void					set_sighandlers_during_execution(void);
 void					set_sighandlers(t_sighandler sighandler);

--- a/test/ast2cmdinvo_test.c
+++ b/test/ast2cmdinvo_test.c
@@ -354,7 +354,7 @@ int main()
 		CHECK_EQ(string_node->type, TOKTYPE_NON_EXPANDABLE);
 		CHECK_EQ_STR(string_node->text, "$ABC");
 
-		char **actual = expand_string_node(args_node->string_node->content.string);
+		char **actual = expand_string_node(args_node->string_node->content.string, false);
 		char **expected = NULL;
 		char **tmp = expected;
 		expected = (char **)ptrarr_add_ptr((void **)expected, ft_strdup("hogeabc"));
@@ -414,10 +414,55 @@ int main()
 		CHECK_EQ(string_node->type, TOKTYPE_EXPANDABLE_QUOTED);
 		CHECK_EQ_STR(string_node->text, "$ABC");
 
-		char **actual = expand_string_node(args_node->string_node->content.string);
+		char **actual = expand_string_node(args_node->string_node->content.string, false);
 		char **expected = NULL;
 		char **tmp = expected;
 		expected = (char **)ptrarr_add_ptr((void **)expected, ft_strdup("$$ABC\\ abc def  abc def "));
+		free(tmp);
+
+		check_strarr((const char **)actual, (const char **)expected);
+		free_ptrarr((void **)actual);
+		free_ptrarr((void **)expected);
+		free(tok.text);
+	}
+
+	TEST_SECTION("expand_string_node() exportコマンドの時の空白区切り");
+	{
+		/* 準備 */
+		ft_setenv("b", "a  b", 0);
+		t_parse_buffer	buf;
+		init_buf_with_string(&buf, "export abc=\"a\"$b\"c\"\n");
+		t_token	tok;
+		lex_init_token(&tok);
+
+		lex_get_token(&buf, &tok);
+
+		t_parse_ast *node = parse_command(&buf, &tok);
+		CHECK_EQ(node->type, ASTNODE_COMMAND);
+		CHECK_EQ(node->content.command->arguments_node->type, ASTNODE_ARGUMENTS);
+		t_parse_node_arguments *args_node = node->content.command->arguments_node->content.arguments;
+		CHECK_EQ(args_node->string_node->content.string->type, TOKTYPE_EXPANDABLE);
+		CHECK_EQ_STR(args_node->string_node->content.string->text, "export");
+
+		args_node = args_node->rest_node->content.arguments;
+
+		t_parse_node_string *string_node = args_node->string_node->content.string;
+		CHECK_EQ(string_node->type, TOKTYPE_EXPANDABLE);
+		CHECK_EQ_STR(string_node->text, "abc=");
+		string_node = string_node->next->content.string;
+		CHECK_EQ(string_node->type, TOKTYPE_EXPANDABLE_QUOTED);
+		CHECK_EQ_STR(string_node->text, "a");
+		string_node = string_node->next->content.string;
+		CHECK_EQ(string_node->type, TOKTYPE_EXPANDABLE);
+		CHECK_EQ_STR(string_node->text, "$b");
+		string_node = string_node->next->content.string;
+		CHECK_EQ(string_node->type, TOKTYPE_EXPANDABLE_QUOTED);
+		CHECK_EQ_STR(string_node->text, "c");
+
+		char **actual = expand_string_node(args_node->string_node->content.string, true);
+		char **expected = NULL;
+		char **tmp = expected;
+		expected = (char **)ptrarr_add_ptr((void **)expected, ft_strdup("abc=aa  bc"));
 		free(tmp);
 
 		check_strarr((const char **)actual, (const char **)expected);


### PR DESCRIPTION
以下のようにexportコマンドの時は環境変数内に空白が入っていても環境変数の値として文字列が連結される. このような挙動をminishellでも行うようにした.

```bash
$ export bc="b  c"                          
$ echo "$bc"
b  c
$ export abcd="a"$bc'd'
$ export | grep abcd
declare -x abcd="ab  cd"
```

![image](https://user-images.githubusercontent.com/26608037/122971614-30c4f200-d3ca-11eb-8047-c35372368f6f.png)
